### PR TITLE
Fallowing a sintax convention

### DIFF
--- a/examples/LILGO_T_HMI/test.cpp
+++ b/examples/LILGO_T_HMI/test.cpp
@@ -15,31 +15,31 @@
 
 void uiInit() {
 	static lvgl::widget::TabView tView = lvgl::widget::TabView(lv_scr_act());
-	tView.addTab("Tab 1");
-	tView.addTab("Tab");
-	tView.addTab("Tab 3");
-	tView.addTab("Tab 4");
-	tView.renameTab(1, "Tab 2");
+	tView.AddTab("Tab 1");
+	tView.AddTab("Tab");
+	tView.AddTab("Tab 3");
+	tView.AddTab("Tab 4");
+	tView.RenameTab(1, "Tab 2");
 
-	lv_obj_t *tab2 = tView.getTabObj("Tab 2");
-	lv_obj_t *tab1 = tView.getTabObj("Tab 1");
-	lv_obj_t *tab3 = tView.getTabObj("Tab 3");
-	lv_obj_t *tab4 = tView.getTabObj("Tab 4");
+	lv_obj_t *tab2 = tView.GetTabObj("Tab 2");
+	lv_obj_t *tab1 = tView.GetTabObj("Tab 1");
+	lv_obj_t *tab3 = tView.GetTabObj("Tab 3");
+	lv_obj_t *tab4 = tView.GetTabObj("Tab 4");
 	static lvgl::widget::ButtonMatrix bMatrix = lvgl::widget::ButtonMatrix(tab2);
 	static const char *btnm_map[] = {
 			"1", "2", "3", "4", "5", "\n",
 			"6", "7", "8", "9", "0", "\n",
 			"Action1", "Action2", ""
 			};
-	bMatrix.setMap(btnm_map);
-	bMatrix.setPos(0, 0);
-	bMatrix.setVisible(false);
-	if(bMatrix.getVisible())
+	bMatrix.SetMap(btnm_map);
+	bMatrix.SetPos(0, 0);
+	bMatrix.SetVisible(false);
+	if(bMatrix.GetVisible())
 		DBG_println("Visible");
 	else
 		DBG_println("Hidden");
-	bMatrix.setVisible(true);
-	if(bMatrix.getVisible())
+	bMatrix.SetVisible(true);
+	if(bMatrix.GetVisible())
 		DBG_println("Visible");
 	else
 		DBG_println("Hidden");
@@ -47,30 +47,30 @@ void uiInit() {
 	static lvgl::widget::Button button = lvgl::widget::Button(tab1, "Button %u", 1);
 
 	static lvgl::widget::Label label = lvgl::widget::Label(tab1, "Label %u", 1);
-	label.setPos(100, 0);
+	label.SetPos(100, 0);
 
 	static lvgl::widget::Arc arc = lvgl::widget::Arc(tab1);
-	arc.setPos(210, 0);
-	arc.setSize(80, 80);
-	arc.setBgAngles(0, 180);
-	arc.setRange(0, 360);
-	arc.setValue(180);
+	arc.SetPos(210, 0);
+	arc.SetSize(80, 80);
+	arc.SetBgAngles(0, 180);
+	arc.SetRange(0, 360);
+	arc.SetValue(180);
 
 	static lvgl::widget::Bar bar = lvgl::widget::Bar(tab1);
-	bar.setPos(0, 40);
-	bar.setSize(80, 20);
-	bar.setRange(0, 50);
-	bar.setValue(25, LV_ANIM_ON);
+	bar.SetPos(0, 40);
+	bar.SetSize(80, 20);
+	bar.SetRange(0, 50);
+	bar.SetValue(25, LV_ANIM_ON);
 
 	static lvgl::widget::CheckBox checkBox = lvgl::widget::CheckBox(tab1);
-	checkBox.setPos(100, 40);
-	checkBox.setSize(110, 40);
-	checkBox.setChecked(true);
+	checkBox.SetPos(100, 40);
+	checkBox.SetSize(110, 40);
+	checkBox.SetChecked(true);
 
 	static lvgl::widget::DropDown dropDown = lvgl::widget::DropDown(tab1);
-	dropDown.setPos(0, 80);
-	dropDown.setSize(160, 40);
-	dropDown.setOptions(""
+	dropDown.SetPos(0, 80);
+	dropDown.SetSize(160, 40);
+	dropDown.SetOptions(""
 			"Apple\n"
 			"Banana\n"
 			"Orange\n"
@@ -84,25 +84,25 @@ void uiInit() {
 
 	LV_IMG_DECLARE(fan30);
 	static lvgl::widget::Image image = lvgl::widget::Image(tab1);
-	image.setPos(0, 120);
-	image.setSize(30, 30);
-	image.setSource(&fan30);
+	image.SetPos(0, 120);
+	image.SetSize(30, 30);
+	image.SetSource(&fan30);
 
 	static lvgl::widget::Line line = lvgl::widget::Line(tab1);
-	line.setPos(40, 120);
-	line.setSize(80, 40);
-	line.setYInvert(true);
+	line.SetPos(40, 120);
+	line.SetSize(80, 40);
+	line.SetYInvert(true);
 	static const lv_point_t points[] = {
 	  {0, 20},
 	  {10, 0},
 	  {30, 30}
 	};
-	line.setPoints(points, 3);
+	line.SetPoints(points, 3);
 
 	static lvgl::widget::Roller roller = lvgl::widget::Roller(tab1);
-	roller.setPos(170, 100);
-	roller.setSize(100, 85);
-	roller.setOptionsInfinite(
+	roller.SetPos(170, 100);
+	roller.SetSize(100, 85);
+	roller.SetOptionsInfinite(
 			"January\n"
 			"February\n"
 			"March\n"
@@ -117,37 +117,37 @@ void uiInit() {
 			"December");
 
   static lvgl::draw::Rectangle rect_dsc = lvgl::draw::Rectangle();
-  rect_dsc.setRadius(10);
-  rect_dsc.setOpacity(LV_OPA_COVER);
-  rect_dsc.setGradientDirection(LV_GRAD_DIR_HOR);
-  rect_dsc.setGradientStopsColor(0, lv_palette_main(LV_PALETTE_RED));
-  rect_dsc.setGradientStopsColor(1, lv_palette_main(LV_PALETTE_BLUE));
-  rect_dsc.setBorderWidth(2);
-  rect_dsc.setBorderOpacityPercent(90);
-  rect_dsc.setBorderColor(lv_color_white());
-  rect_dsc.setShadowWidth(5);
-  rect_dsc.setShadowOffsetX(5);
-  rect_dsc.setShadowOffsetY(5);
+  rect_dsc.SetRadius(10);
+  rect_dsc.SetOpacity(LV_OPA_COVER);
+  rect_dsc.SetGradientDirection(LV_GRAD_DIR_HOR);
+  rect_dsc.SetGradientStopsColor(0, lv_palette_main(LV_PALETTE_RED));
+  rect_dsc.SetGradientStopsColor(1, lv_palette_main(LV_PALETTE_BLUE));
+  rect_dsc.SetBorderWidth(2);
+  rect_dsc.SetBorderOpacityPercent(90);
+  rect_dsc.SetBorderColor(lv_color_white());
+  rect_dsc.SetShadowWidth(5);
+  rect_dsc.SetShadowOffsetX(5);
+  rect_dsc.SetShadowOffsetY(5);
 
 	static uint8_t cbuf[LV_CANVAS_BUF_SIZE_TRUE_COLOR(200, 150)];
 	static lvgl::widget::Canvas canvas = lvgl::widget::Canvas(tab3);
-	canvas.setBuffer(cbuf, 200, 150, LV_IMG_CF_TRUE_COLOR);
-	canvas.drawRectangle(70, 60, 100, 70, &rect_dsc);
+	canvas.SetBuffer(cbuf, 200, 150, LV_IMG_CF_TRUE_COLOR);
+	canvas.DrawRectangle(70, 60, 100, 70, &rect_dsc);
 
 	static lvgl::widget::Switch sw = lvgl::widget::Switch(tab4);
-	sw.setPos(0, 0);
-	sw.setSize(80, 40);
-	sw.setChecked(true);
+	sw.SetPos(0, 0);
+	sw.SetSize(80, 40);
+	sw.SetChecked(true);
 
 	static lvgl::widget::Table table = lvgl::widget::Table(tab4);
-	table.setPos(0, 50);
-	table.setSize(270, 130);
-	table.setColCount(2);
-	table.setRowCount(2);
-	table.setCellValue(0, 0, "Row 1");
-	table.setCellValue(0, 1, "Val %u", 1);
-	table.setCellValue(1, 0, "Row 2");
-	table.setCellValue(1, 1, "Val %u", 2);
-	table.setCellValue(2, 0, "Row 3");
-	table.setCellValue(2, 1, "Val %u", 3);
+	table.SetPos(0, 50);
+	table.SetSize(270, 130);
+	table.SetColCount(2);
+	table.SetRowCount(2);
+	table.SetCellValue(0, 0, "Row 1");
+	table.SetCellValue(0, 1, "Val %u", 1);
+	table.SetCellValue(1, 0, "Row 2");
+	table.SetCellValue(1, 1, "Val %u", 2);
+	table.SetCellValue(2, 0, "Row 3");
+	table.SetCellValue(2, 1, "Val %u", 3);
 }

--- a/src/draw/Arc.h
+++ b/src/draw/Arc.h
@@ -1,8 +1,7 @@
 /*
  * Arc.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_DRAW_SRC_ARC_H_
@@ -24,7 +23,7 @@ namespace lvgl {
 				}
 			}
 			
-			inline lv_draw_arc_dsc_t *get() {
+			inline lv_draw_arc_dsc_t *Get() {
 				return &arc;
 			}
 
@@ -34,67 +33,67 @@ namespace lvgl {
 				}
 			}
 
-			inline Arc *setColor(lv_color_t color) {
+			inline Arc *SetColor(lv_color_t color) {
 				arc.color = color;
 				return this;
 			}
-			inline lv_color_t getColor() {
+			inline lv_color_t GetColor() {
 				return arc.color;
 			}
 
-			inline Arc *setWidth(lv_coord_t width) {
+			inline Arc *SetWidth(lv_coord_t width) {
 				arc.width = width;
 				return this;
 			}
-			inline lv_coord_t getWidth() {
+			inline lv_coord_t GetWidth() {
 				return arc.width;
 			}
 
-			inline Arc *setStartAngle(uint16_t start_angle) {
+			inline Arc *SetStartAngle(uint16_t start_angle) {
 				arc.start_angle = start_angle;
 				return this;
 			}
-			inline uint16_t getStartAngle() {
+			inline uint16_t GetStartAngle() {
 				return arc.start_angle;
 			}
 
-			inline Arc *setEndAngle(uint16_t end_angle) {
+			inline Arc *SetEndAngle(uint16_t end_angle) {
 				arc.end_angle = end_angle;
 				return this;
 			}
-			inline uint16_t getEndAngle() {
+			inline uint16_t GetEndAngle() {
 				return arc.end_angle;
 			}
 
-			inline Arc *setImageSource(const void * img_src) {
+			inline Arc *SetImageSource(const void * img_src) {
 				arc.img_src = img_src;
 				return this;
 			}
-			inline const void * getImageSource() {
+			inline const void * GetImageSource() {
 				return arc.img_src;
 			}
 
-			inline Arc *setOpacity(lv_opa_t opa) {
+			inline Arc *SetOpacity(lv_opa_t opa) {
 				arc.opa = opa;
 				return this;
 			}
-			inline lv_opa_t getOpacity() {
+			inline lv_opa_t GetOpacity() {
 				return arc.opa;
 			}
 
-			inline Arc *setBlendMode(lv_blend_mode_t blend_mode) {
+			inline Arc *SetBlendMode(lv_blend_mode_t blend_mode) {
 				arc.blend_mode = blend_mode;
 				return this;
 			}
-			inline lv_blend_mode_t getBlendMode() {
+			inline lv_blend_mode_t GetBlendMode() {
 				return arc.blend_mode;
 			}
 
-			inline Arc *setRounded(uint8_t rounded) {
+			inline Arc *SetRounded(uint8_t rounded) {
 				arc.rounded = rounded;
 				return this;
 			}
-			inline uint8_t getRounded() {
+			inline uint8_t GetRounded() {
 				return arc.rounded;
 			}
 
@@ -112,6 +111,11 @@ namespace lvgl {
 			static inline void drawArc(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_arc_dsc_t * dsc, const lv_point_t * center,
 								 uint16_t radius,  uint16_t start_angle, uint16_t end_angle) {
 				lv_draw_arc(draw_ctx, dsc, center, radius, start_angle, end_angle);
+			}
+
+			static inline void drawArc(struct _lv_draw_ctx_t * draw_ctx, lvgl::draw::Arc * dsc, const lv_point_t * center,
+								 uint16_t radius,  uint16_t start_angle, uint16_t end_angle) {
+				lv_draw_arc(draw_ctx, dsc->Get(), center, radius, start_angle, end_angle);
 			}
 
 /**

--- a/src/draw/Label.h
+++ b/src/draw/Label.h
@@ -1,0 +1,196 @@
+/*
+ * Label.h
+ *
+ *      Author: Iulian Gheorghiu
+ */
+
+#ifndef LVGLCPP_DRAW_SRC_LABEL_H_
+#define LVGLCPP_DRAW_SRC_LABEL_H_
+
+#include <lvgl.h>
+#include <stdlib.h>
+
+namespace lvgl {
+	namespace draw {
+		class Label {
+		public:
+			Label() {
+				lv_draw_label_dsc_init(&label);
+			}
+			Label(Label *label) {
+				if(label) {
+					memcpy(&label->label, &label, sizeof(lv_draw_label_dsc_t));
+				}
+			}
+			
+			inline lv_draw_label_dsc_t *Get() {
+				return &label;
+			}
+
+			inline void clone(Label *label) {
+				if(label) {
+					memcpy(&label->label, &label, sizeof(lv_draw_label_dsc_t));
+				}
+			}
+
+			inline Label *SetFont(const lv_font_t *font) {
+				label.font = font;
+				return this;
+			}
+			inline const lv_font_t *GetFont() {
+				return label.font;
+			}
+
+			inline Label *SetSelectStart(uint32_t sel_start) {
+				label.sel_start = sel_start;
+				return this;
+			}
+			inline uint32_t GetSelectStart() {
+				return label.sel_start;
+			}
+
+			inline Label *SetSelectEnd(uint32_t sel_end) {
+				label.sel_end = sel_end;
+				return this;
+			}
+			inline uint32_t GetSelectEnd() {
+				return label.sel_end;
+			}
+
+			inline Label *SetColor(lv_color_t color) {
+				label.color = color;
+				return this;
+			}
+			inline lv_color_t GetColor() {
+				return label.color;
+			}
+
+			inline Label *SetSelectColor(lv_color_t sel_color) {
+				label.sel_color = sel_color;
+				return this;
+			}
+			inline lv_color_t GetSelectColor() {
+				return label.sel_color;
+			}
+
+			inline Label *SetBgColor(lv_color_t sel_bg_color) {
+				label.sel_bg_color = sel_bg_color;
+				return this;
+			}
+			inline lv_color_t GetBgColor() {
+				return label.sel_bg_color;
+			}
+
+			inline Label *SetLineSpace(lv_coord_t line_space) {
+				label.line_space = line_space;
+				return this;
+			}
+			inline lv_coord_t GetLineSpace() {
+				return label.line_space;
+			}
+
+			inline Label *SetLetterSpace(lv_coord_t letter_space) {
+				label.letter_space = letter_space;
+				return this;
+			}
+			inline lv_coord_t GetLetterSpace() {
+				return label.letter_space;
+			}
+
+			inline Label *SetOffsetX(lv_coord_t ofs_x) {
+				label.ofs_x = ofs_x;
+				return this;
+			}
+			inline lv_coord_t GetOffsetX() {
+				return label.ofs_x;
+			}
+
+			inline Label *SetOffsetY(lv_coord_t ofs_y) {
+				label.ofs_y = ofs_y;
+				return this;
+			}
+			inline lv_coord_t GetOffsetY() {
+				return label.ofs_y;
+			}
+
+			inline Label *SetOpacity(lv_opa_t opa) {
+				label.opa = opa;
+				return this;
+			}
+			inline lv_opa_t GetOpacity() {
+				return label.opa;
+			}
+
+			inline Label *SetBidiDirection(lv_base_dir_t bidi_dir) {
+				label.bidi_dir = bidi_dir;
+				return this;
+			}
+			inline lv_base_dir_t GetBidiDirection() {
+				return label.bidi_dir;
+			}
+
+			inline Label *SetAlign(lv_text_align_t align) {
+				label.align = align;
+				return this;
+			}
+			inline lv_text_align_t GetAlign() {
+				return label.align;
+			}
+
+			inline Label *SetFlag(lv_text_flag_t flag) {
+				label.flag = flag;
+				return this;
+			}
+			inline lv_text_flag_t GetFlag() {
+				return label.flag;
+			}
+
+			inline Label *SetDecoration(lv_text_decor_t decor) {
+				label.decor = decor;
+				return this;
+			}
+			inline lv_text_decor_t GetDecoration() {
+				return label.decor;
+			}
+
+			inline Label *SetBlendMode(lv_blend_mode_t blend_mode) {
+				label.blend_mode = blend_mode;
+				return this;
+			}
+			inline lv_blend_mode_t GetBlendMode() {
+				return label.blend_mode;
+			}
+
+/**
+ * Write a text
+ * @param coords coordinates of the label
+ * @param mask the label will be drawn only in this area
+ * @param dsc pointer to draw descriptor
+ * @param txt `\0` terminated text to write
+ * @param hint pointer to a `lv_draw_label_hint_t` variable.
+ * It is managed by the draw to speed up the drawing of very long texts (thousands of lines).
+ */
+ 			static inline void drawLabel(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,
+                                               const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint) {
+				lv_draw_label(draw_ctx, dsc, coords, txt, hint);
+			}
+
+ 			static inline void drawLabel(struct _lv_draw_ctx_t * draw_ctx, lvgl::draw::Label *dsc,
+                                               const lv_area_t * coords, const char * txt, lv_draw_label_hint_t * hint) {
+				lv_draw_label(draw_ctx, dsc->Get(), coords, txt, hint);
+			}
+
+			static inline void drawLetter(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_label_dsc_t * dsc,  const lv_point_t * pos_p, uint32_t letter) {
+				lv_draw_letter(draw_ctx, dsc, pos_p, letter);
+			}
+
+			static inline void drawLetter(struct _lv_draw_ctx_t * draw_ctx, lvgl::draw::Label *dsc,  const lv_point_t * pos_p, uint32_t letter) {
+				lv_draw_letter(draw_ctx, dsc->Get(), pos_p, letter);
+			}
+		private:
+			lv_draw_label_dsc_t label;
+		};
+	}
+}
+
+#endif

--- a/src/draw/Line.h
+++ b/src/draw/Line.h
@@ -1,8 +1,7 @@
 /*
- * line.h
+ * Line.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_DRAW_SRC_LINE_H_
@@ -24,7 +23,7 @@ namespace lvgl {
 				}
 			}
 			
-			inline lv_draw_line_dsc_t *get() {
+			inline lv_draw_line_dsc_t *Get() {
 				return &line;
 			}
 
@@ -34,75 +33,75 @@ namespace lvgl {
 				}
 			}
 
-			inline Line *setColor(lv_color_t color) {
+			inline Line *SetColor(lv_color_t color) {
 				line.color = color;
 				return this;
 			}
-			inline lv_color_t getColor() {
+			inline lv_color_t GetColor() {
 				return line.color;
 			}
 
-			inline Line *setWidth(lv_coord_t width) {
+			inline Line *SetWidth(lv_coord_t width) {
 				line.width = width;
 				return this;
 			}
-			inline lv_coord_t getWidth() {
+			inline lv_coord_t GetWidth() {
 				return line.width;
 			}
 
-			inline Line *setDashWidth(lv_coord_t dash_width) {
+			inline Line *SetDashWidth(lv_coord_t dash_width) {
 				line.dash_width = dash_width;
 				return this;
 			}
-			inline lv_coord_t getDashWidth() {
+			inline lv_coord_t GetDashWidth() {
 				return line.dash_width;
 			}
 
-			inline Line *setDashGap(lv_coord_t dash_gap) {
+			inline Line *SetDashGap(lv_coord_t dash_gap) {
 				line.dash_gap = dash_gap;
 				return this;
 			}
-			inline lv_coord_t getDashGap() {
+			inline lv_coord_t GetDashGap() {
 				return line.dash_gap;
 			}
 
-			inline Line *setOpacity(lv_opa_t opa) {
+			inline Line *SetOpacity(lv_opa_t opa) {
 				line.opa = opa;
 				return this;
 			}
-			inline lv_opa_t getOpacity() {
+			inline lv_opa_t GetOpacity() {
 				return line.opa;
 			}
 
-			inline Line *setBlendMode(lv_blend_mode_t blend_mode) {
+			inline Line *SetBlendMode(lv_blend_mode_t blend_mode) {
 				line.blend_mode = blend_mode;
 				return this;
 			}
-			inline lv_blend_mode_t getBlendMode() {
+			inline lv_blend_mode_t GetBlendMode() {
 				return line.blend_mode;
 			}
 
-			inline Line *setRoundStart(uint8_t round_start) {
+			inline Line *SetRoundStart(uint8_t round_start) {
 				line.round_start = round_start;
 				return this;
 			}
-			inline uint8_t getRoundStart() {
+			inline uint8_t GetRoundStart() {
 				return line.round_start;
 			}
 
-			inline Line *setRoundEnd(uint8_t round_end) {
+			inline Line *SetRoundEnd(uint8_t round_end) {
 				line.round_end = round_end;
 				return this;
 			}
-			inline uint8_t getRoundEnd() {
+			inline uint8_t GetRoundEnd() {
 				return line.round_end;
 			}
 			/*Do not bother with perpendicular line ending if it's not visible for any reason*/
-			inline Line *setRawEnd(uint8_t raw_end) {
+			inline Line *SetRawEnd(uint8_t raw_end) {
 				line.raw_end = raw_end;
 				return this;
 			}
-			inline uint8_t getRawEnd() {
+			inline uint8_t GetRawEnd() {
 				return line.raw_end;
 			}
 
@@ -116,6 +115,11 @@ namespace lvgl {
 			static inline void drawLine(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_line_dsc_t * dsc,
                                               const lv_point_t * point1, const lv_point_t * point2) {
 				lv_draw_line(draw_ctx, dsc, point1, point2);
+			}
+
+			static inline void drawLine(struct _lv_draw_ctx_t * draw_ctx, lvgl::draw::Line * dsc,
+                                              const lv_point_t * point1, const lv_point_t * point2) {
+				lv_draw_line(draw_ctx, dsc->Get(), point1, point2);
 			}
 
 			private:

--- a/src/draw/Rectangle.h
+++ b/src/draw/Rectangle.h
@@ -1,3 +1,9 @@
+/*
+ * Rectangle.h
+ *
+ *      Author: Iulian Gheorghiu
+ */
+
 #ifndef LVCPP_DRAW_LVRECTANGLE_H_
 #define LVCPP_DRAW_LVRECTANGLE_H_
 
@@ -18,267 +24,267 @@ namespace lvgl {
 				}
 			}
 			
-			inline lv_draw_rect_dsc_t *get() {
+			inline lv_draw_rect_dsc_t *Get() {
 				return &rectangle;
 			}
 
-			inline void clone(Rectangle *rec) {
+			inline void Clone(Rectangle *rec) {
 				if(rec) {
 					memcpy(&rec->rectangle, &rectangle, sizeof(lv_draw_rect_dsc_t));
 				}
 			}
 
-			inline Rectangle *setRadius(lv_coord_t radius) {
+			inline Rectangle *SetRadius(lv_coord_t radius) {
 				rectangle.radius = radius;
 				return this;
 			}
-			inline lv_coord_t getRadius() {
+			inline lv_coord_t GetRadius() {
 				return rectangle.radius;
 			}
 
-			inline Rectangle *setBlendMode(lv_blend_mode_t blend_mode) {
+			inline Rectangle *SetBlendMode(lv_blend_mode_t blend_mode) {
 				rectangle.blend_mode = blend_mode;
 				return this;
 			}
-			inline lv_blend_mode_t getBlendMode() {
+			inline lv_blend_mode_t GetBlendMode() {
 				return rectangle.blend_mode;
 			}
 
 			/*Background*/
-			inline Rectangle *setOpacity(lv_opa_t bg_opa) {
+			inline Rectangle *SetOpacity(lv_opa_t bg_opa) {
 				rectangle.bg_opa = bg_opa;
 				return this;
 			}
-			inline lv_opa_t getOpacity() {
+			inline lv_opa_t GetOpacity() {
 				return rectangle.bg_opa;
 			}
 
 			/**< First element of a gradient is a color, so it maps well here*/
-			inline Rectangle *setColor(lv_color_t bg_color) {
+			inline Rectangle *SetColor(lv_color_t bg_color) {
 				rectangle.bg_color = bg_color;
 				return this;
 			}
-			inline lv_color_t getColor() {
+			inline lv_color_t GetColor() {
 				return rectangle.bg_color;
 			}
 
-			inline Rectangle *setGradientDirection(lv_grad_dir_t bg_grad_dir) {
+			inline Rectangle *SetGradientDirection(lv_grad_dir_t bg_grad_dir) {
 				rectangle.bg_grad.dir = bg_grad_dir;
 				return this;
 			}
-			inline lv_grad_dir_t getGradientDirection() {
+			inline lv_grad_dir_t GetGradientDirection() {
 				return rectangle.bg_grad.dir;
 			}
 
-			inline Rectangle *setGradientStopsCount(uint8_t stops_count) {
+			inline Rectangle *SetGradientStopsCount(uint8_t stops_count) {
 				rectangle.bg_grad.stops_count = stops_count;
 				return this;
 			}
-			inline uint8_t getGradientStopsCount() {
+			inline uint8_t GetGradientStopsCount() {
 				return rectangle.bg_grad.stops_count;
 			}
 
-			inline Rectangle *setGradientStopsColor(uint8_t idx, lv_color_t color) {
+			inline Rectangle *SetGradientStopsColor(uint8_t idx, lv_color_t color) {
 				rectangle.bg_grad.stops[idx].color = color;
 				return this;
 			}
-			inline lv_color_t getGradientStopsColor(uint8_t idx) {
+			inline lv_color_t GetGradientStopsColor(uint8_t idx) {
 				return rectangle.bg_grad.stops[idx].color;
 			}
 
-			inline Rectangle *setGradientStopsFraction(uint8_t idx, uint8_t fraction) {
+			inline Rectangle *SetGradientStopsFraction(uint8_t idx, uint8_t fraction) {
 				rectangle.bg_grad.stops[idx].frac = fraction;
 				return this;
 			}
-			inline uint8_t getGradientStopsFraction(uint8_t idx) {
+			inline uint8_t GetGradientStopsFraction(uint8_t idx) {
 				return rectangle.bg_grad.stops[idx].frac;
 			}
 
-			inline Rectangle *setGradientDither(lv_dither_mode_t dither) {
+			inline Rectangle *SetGradientDither(lv_dither_mode_t dither) {
 				rectangle.bg_grad.dither = dither;
 				return this;
 			}
-			inline lv_dither_mode_t getGradientDither() {
+			inline lv_dither_mode_t GetGradientDither() {
 				return rectangle.bg_grad.dither;
 			}
 
 			/*Background img*/
-			inline Rectangle *setImageSource(const void * bg_img_src) {
+			inline Rectangle *SetImageSource(const void * bg_img_src) {
 				rectangle.bg_img_src = bg_img_src;
 				return this;
 			}
-			inline const void * getImageSource() {
+			inline const void * GetImageSource() {
 				return rectangle.bg_img_src;
 			}
 
-			inline Rectangle *setImageSymbolFont(const void * bg_img_symbol_font) {
+			inline Rectangle *SetImageSymbolFont(const void * bg_img_symbol_font) {
 				rectangle.bg_img_symbol_font = bg_img_symbol_font;
 				return this;
 			}
-			inline const void * getImageSymbolFont() {
+			inline const void * GetImageSymbolFont() {
 				return rectangle.bg_img_symbol_font;
 			}
 
-			inline Rectangle *setImageReColor(lv_color_t bg_img_recolor) {
+			inline Rectangle *SetImageReColor(lv_color_t bg_img_recolor) {
 				rectangle.bg_img_recolor = bg_img_recolor;
 				return this;
 			}
-			inline lv_color_t getImageReColor() {
+			inline lv_color_t GetImageReColor() {
 				return rectangle.bg_img_recolor;
 			}
 
-			inline Rectangle *setImageOpacity(lv_opa_t bg_img_opa) {
+			inline Rectangle *SetImageOpacity(lv_opa_t bg_img_opa) {
 				rectangle.bg_img_opa = bg_img_opa;
 				return this;
 			}
-			inline lv_opa_t getImageOpacity() {
+			inline lv_opa_t GetImageOpacity() {
 				return rectangle.bg_img_opa;
 			}
 
-			inline Rectangle *setImageReColorOpacity(lv_opa_t bg_img_recolor_opa) {
+			inline Rectangle *SetImageReColorOpacity(lv_opa_t bg_img_recolor_opa) {
 				rectangle.bg_img_recolor_opa = bg_img_recolor_opa;
 				return this;
 			}
-			inline lv_opa_t getImageReColorOpacity() {
+			inline lv_opa_t GetImageReColorOpacity() {
 				return rectangle.bg_img_recolor_opa;
 			}
 
-			inline Rectangle *setImageTiled(uint8_t bg_img_tiled) {
+			inline Rectangle *SetImaGetiled(uint8_t bg_img_tiled) {
 				rectangle.bg_img_tiled = bg_img_tiled;
 				return this;
 			}
-			inline uint8_t getImageTiled() {
+			inline uint8_t GetImaGetiled() {
 				return rectangle.bg_img_tiled;
 			}
 
 			/*Border*/
-			inline Rectangle *setBorderColor(lv_color_t border_color) {
+			inline Rectangle *SetBorderColor(lv_color_t border_color) {
 				rectangle.border_color = border_color;
 				return this;
 			}
-			inline lv_color_t getBorderColor() {
+			inline lv_color_t GetBorderColor() {
 				return rectangle.border_color;
 			}
 
-			inline Rectangle *setBorderWidth(lv_coord_t border_width) {
+			inline Rectangle *SetBorderWidth(lv_coord_t border_width) {
 				rectangle.border_width = border_width;
 				return this;
 			}
-			inline lv_coord_t getBorderWidth() {
+			inline lv_coord_t GetBorderWidth() {
 				return rectangle.border_width;
 			}
 
-			inline Rectangle *setBorderOpacity(lv_opa_t border_opa) {
+			inline Rectangle *SetBorderOpacity(lv_opa_t border_opa) {
 				rectangle.border_opa = border_opa;
 				return this;
 			}
-			inline lv_opa_t getBorderOpacity() {
+			inline lv_opa_t GetBorderOpacity() {
 				return rectangle.border_opa;
 			}
-			inline Rectangle *setBorderOpacityPercent(uint8_t border_opa) {
+			inline Rectangle *SetBorderOpacityPercent(uint8_t border_opa) {
 				rectangle.border_opa = map(border_opa, 0, 100, 0, 255);
 				return this;
 			}
-			inline lv_opa_t getBorderOpacityPercent() {
+			inline lv_opa_t GetBorderOpacityPercent() {
 				return map(rectangle.border_opa, 0, 255, 0, 100);
 			}
 
 			/*There is a border it will be drawn later.*/
-			inline Rectangle *setBorderPost(uint8_t border_post) {
+			inline Rectangle *SetBorderPost(uint8_t border_post) {
 				rectangle.border_post = border_post;
 				return this;
 			}
-			inline uint8_t getBorderPost() {
+			inline uint8_t GetBorderPost() {
 				return rectangle.border_post;
 			}
 
-			inline Rectangle *setBorderSide(lv_border_side_t border_side) {
+			inline Rectangle *SetBorderSide(lv_border_side_t border_side) {
 				rectangle.border_side = border_side;
 				return this;
 			}
-			inline lv_border_side_t getBorderSide() {
+			inline lv_border_side_t GetBorderSide() {
 				return rectangle.border_side;
 			}
 
 			/*Outline*/
-			inline Rectangle *setOutlineColor(lv_color_t outline_color) {
+			inline Rectangle *SetOutlineColor(lv_color_t outline_color) {
 				rectangle.outline_color = outline_color;
 				return this;
 			}
-			inline lv_color_t getOutlineColor() {
+			inline lv_color_t GetOutlineColor() {
 				return rectangle.outline_color;
 			}
 
-			inline Rectangle *setOutlineWidth(lv_coord_t outline_width) {
+			inline Rectangle *SetOutlineWidth(lv_coord_t outline_width) {
 				rectangle.outline_width = outline_width;
 				return this;
 			}
-			inline lv_coord_t getOutlineWidth() {
+			inline lv_coord_t GetOutlineWidth() {
 				return rectangle.outline_width;
 			}
 
-			inline Rectangle *setOutlinePad(lv_coord_t outline_pad) {
+			inline Rectangle *SetOutlinePad(lv_coord_t outline_pad) {
 				rectangle.outline_pad = outline_pad;
 				return this;
 			}
-			inline lv_coord_t getOutlinePad() {
+			inline lv_coord_t GetOutlinePad() {
 				return rectangle.outline_pad;
 			}
 
-			inline Rectangle *setOutlineOpacity(lv_opa_t outline_opa) {
+			inline Rectangle *SetOutlineOpacity(lv_opa_t outline_opa) {
 				rectangle.outline_opa = outline_opa;
 				return this;
 			}
-			inline lv_opa_t getOutlineOpacity() {
+			inline lv_opa_t GetOutlineOpacity() {
 				return rectangle.outline_opa;
 			}
 
 			/*Shadow*/
-			inline Rectangle *setShadowColor(lv_color_t shadow_color) {
+			inline Rectangle *SetShadowColor(lv_color_t shadow_color) {
 				rectangle.shadow_color = shadow_color;
 				return this;
 			}
-			inline lv_color_t getShadowColor() {
+			inline lv_color_t GetShadowColor() {
 				return rectangle.shadow_color;
 			}
 
-			inline Rectangle *setShadowWidth(lv_coord_t shadow_width) {
+			inline Rectangle *SetShadowWidth(lv_coord_t shadow_width) {
 				rectangle.shadow_width = shadow_width;
 				return this;
 			}
-			inline lv_coord_t getShadowWidth() {
+			inline lv_coord_t GetShadowWidth() {
 				return rectangle.shadow_width;
 			}
 
-			inline Rectangle *setShadowOffsetX(lv_coord_t shadow_ofs_x) {
+			inline Rectangle *SetShadowOffsetX(lv_coord_t shadow_ofs_x) {
 				rectangle.shadow_ofs_x = shadow_ofs_x;
 				return this;
 			}
-			inline lv_coord_t getShadowOffsetX() {
+			inline lv_coord_t GetShadowOffsetX() {
 				return rectangle.shadow_ofs_x;
 			}
 
-			inline Rectangle *setShadowOffsetY(lv_coord_t shadow_ofs_y) {
+			inline Rectangle *SetShadowOffsetY(lv_coord_t shadow_ofs_y) {
 				rectangle.shadow_ofs_y = shadow_ofs_y;
 				return this;
 			}
-			inline lv_coord_t getShadowOffsetY() {
+			inline lv_coord_t GetShadowOffsetY() {
 				return rectangle.shadow_ofs_y;
 			}
 
-			inline Rectangle *setShadowSpread(lv_coord_t shadow_spread) {
+			inline Rectangle *SetShadowSpread(lv_coord_t shadow_spread) {
 				rectangle.shadow_spread = shadow_spread;
 				return this;
 			}
-			inline lv_coord_t getShadowSpread() {
+			inline lv_coord_t GetShadowSpread() {
 				return rectangle.shadow_spread;
 			}
 
-			inline Rectangle *setShadowOpacity(lv_opa_t shadow_opa) {
+			inline Rectangle *SetShadowOpacity(lv_opa_t shadow_opa) {
 				rectangle.shadow_opa = shadow_opa;
 				return this;
 			}
-			inline lv_opa_t getShadowOpacity() {
+			inline lv_opa_t GetShadowOpacity() {
 				return rectangle.shadow_opa;
 			}
 /**
@@ -289,6 +295,10 @@ namespace lvgl {
  */
 			static inline void drawRectangle(struct _lv_draw_ctx_t * draw_ctx, const lv_draw_rect_dsc_t * dsc, const lv_area_t * coords) {
 				lv_draw_rect(draw_ctx, dsc, coords);
+			}
+
+			static inline void drawRectangle(struct _lv_draw_ctx_t * draw_ctx, lvgl::draw::Rectangle * dsc, const lv_area_t * coords) {
+				lv_draw_rect(draw_ctx, dsc->Get(), coords);
 			}
 
 			private:

--- a/src/lvglCpp.h
+++ b/src/lvglCpp.h
@@ -1,8 +1,7 @@
 /*
- * lv.h
+ * lvglCpp.h
  *
- *  Created on: Nov 26, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_LVGLCPP_H_
@@ -14,6 +13,7 @@
 #endif
 
 #include "draw/Arc.h"
+#include "draw/Label.h"
 #include "draw/Line.h"
 #include "draw/Rectangle.h"
 

--- a/src/widgets/Arc.h
+++ b/src/widgets/Arc.h
@@ -1,8 +1,7 @@
 /*
  * Arc.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_ARC_H_
@@ -39,12 +38,12 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline Arc *setObj(lv_obj_t *obj) {
+			inline Arc *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -61,7 +60,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @param start the start angle
 			 */
-			inline Arc *setStartAngle(uint16_t start) {
+			inline Arc *SetStartAngle(uint16_t start) {
 				lv_arc_set_start_angle(_obj, start);
 				return this;
 			}
@@ -71,7 +70,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @param end   the end angle
 			 */
-			inline Arc *setEndAngle(uint16_t end) {
+			inline Arc *SetEndAngle(uint16_t end) {
 				lv_arc_set_end_angle(_obj, end);
 				return this;
 			}
@@ -82,7 +81,7 @@ namespace lvgl {
 			 * @param start the start angle
 			 * @param end   the end angle
 			 */
-			inline Arc *setAngles(uint16_t start, uint16_t end) {
+			inline Arc *SetAngles(uint16_t start, uint16_t end) {
 				lv_arc_set_angles(_obj, start, end);
 				return this;
 			}
@@ -92,7 +91,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @param start the start angle
 			 */
-			inline Arc *setBgStartAngle(uint16_t start) {
+			inline Arc *SetBgStartAngle(uint16_t start) {
 				lv_arc_set_bg_start_angle(_obj, start);
 				return this;
 			}
@@ -102,7 +101,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @param end   the end angle
 			 */
-			inline Arc *setBgEndAngle(uint16_t end) {
+			inline Arc *SetBgEndAngle(uint16_t end) {
 				lv_arc_set_bg_end_angle(_obj, end);
 				return this;
 			}
@@ -113,7 +112,7 @@ namespace lvgl {
 			 * @param start the start angle
 			 * @param end   the end angle
 			 */
-			inline Arc *setBgAngles(uint16_t start, uint16_t end) {
+			inline Arc *SetBgAngles(uint16_t start, uint16_t end) {
 				lv_arc_set_bg_angles(_obj, start, end);
 				return this;
 			}
@@ -123,7 +122,7 @@ namespace lvgl {
 			 * @param obj       pointer to an arc object
 			 * @param rotation  rotation angle
 			 */
-			inline Arc *setRotation(uint16_t rotation) {
+			inline Arc *SetRotation(uint16_t rotation) {
 				lv_arc_set_rotation(_obj, rotation);
 				return this;
 			}
@@ -133,7 +132,7 @@ namespace lvgl {
 			 * @param obj   pointer to arc object
 			 * @param mode  arc's mode
 			 */
-			inline Arc *setMode(lv_arc_mode_t type) {
+			inline Arc *SetMode(lv_arc_mode_t type) {
 				lv_arc_set_mode(_obj, type);
 				return this;
 			}
@@ -143,7 +142,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @param value new value
 			 */
-			inline Arc *setValue(int16_t value) {
+			inline Arc *SetValue(int16_t value) {
 				lv_arc_set_value(_obj, value);
 				return this;
 			}
@@ -154,7 +153,7 @@ namespace lvgl {
 			 * @param min   minimum value
 			 * @param max   maximum value
 			 */
-			inline Arc *setRange(int16_t min, int16_t max) {
+			inline Arc *SetRange(int16_t min, int16_t max) {
 				lv_arc_set_range(_obj, min, max);
 				return this;
 			}
@@ -164,7 +163,7 @@ namespace lvgl {
 			 * @param obj       pointer to an arc object
 			 * @param rate      the change rate
 			 */
-			inline Arc *setChangeRate(uint16_t rate) {
+			inline Arc *SetChangeRate(uint16_t rate) {
 				lv_arc_set_change_rate(_obj, rate);
 				return this;
 			}
@@ -178,7 +177,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @return      the start angle [0..360]
 			 */
-			inline uint16_t getAngleStart() {
+			inline uint16_t GetAngleStart() {
 				return lv_arc_get_angle_start(_obj);
 			}
 
@@ -187,14 +186,16 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @return      the end angle [0..360]
 			 */
-			inline uint16_t lv_arc_get_angle_end(lv_obj_t * obj);
+			inline uint16_t GetAngleEnd() {
+				return lv_arc_get_angle_end(_obj);
+			}
 
 			/**
 			 * Get the start angle of an arc background.
 			 * @param obj   pointer to an arc object
 			 * @return      the  start angle [0..360]
 			 */
-			inline uint16_t getBgAngleStart() {
+			inline uint16_t GetBgAngleStart() {
 				return lv_arc_get_bg_angle_start(_obj);
 			}
 
@@ -203,7 +204,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @return      the end angle [0..360]
 			 */
-			inline uint16_t getBgAngleEnd() {
+			inline uint16_t GetBgAngleEnd() {
 				return lv_arc_get_bg_angle_end(_obj);
 			}
 
@@ -212,7 +213,7 @@ namespace lvgl {
 			 * @param obj       pointer to an arc object
 			 * @return          the value of the arc
 			 */
-			inline int16_t getValue() {
+			inline int16_t GetValue() {
 				return lv_arc_get_value((const lv_obj_t *)_obj);
 			}
 
@@ -221,7 +222,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @return      the minimum value of the arc
 			 */
-			inline int16_t getMinValue() {
+			inline int16_t GetMinValue() {
 				return lv_arc_get_min_value((const lv_obj_t *)_obj);
 			}
 
@@ -230,7 +231,7 @@ namespace lvgl {
 			 * @param obj   pointer to an arc object
 			 * @return      the maximum value of the arc
 			 */
-			inline int16_t getMaxValue() {
+			inline int16_t GetMaxValue() {
 				return lv_arc_get_max_value((const lv_obj_t *)_obj);
 			}
 
@@ -239,7 +240,7 @@ namespace lvgl {
 			 * @param obj       pointer to an arc object
 			 * @return          arc's mode
 			 */
-			inline lv_arc_mode_t getMode() {
+			inline lv_arc_mode_t GetMode() {
 				return lv_arc_get_mode((const lv_obj_t *)_obj);
 			}
 
@@ -253,7 +254,7 @@ namespace lvgl {
 			 * @param obj_to_align  pointer to an object to align
 			 * @param r_offset      consider the radius larger with this value (< 0: for smaller radius)
 			 */
-			inline Arc *alignObjectToAngle(lv_obj_t * obj_to_align, lv_coord_t r_offset) {
+			inline Arc *AlignObjectToAngle(lv_obj_t * obj_to_align, lv_coord_t r_offset) {
 				lv_arc_align_obj_to_angle((const lv_obj_t *)_obj, obj_to_align, r_offset);
 				return this;
 			}
@@ -264,7 +265,7 @@ namespace lvgl {
 			 * @param obj_to_align  pointer to an object to rotate
 			 * @param r_offset      consider the radius larger with this value (< 0: for smaller radius)
 			 */
-			inline Arc *rotateObjectToAngle(lv_obj_t * obj_to_rotate, lv_coord_t r_offset) {
+			inline Arc *RotateObjectToAngle(lv_obj_t * obj_to_rotate, lv_coord_t r_offset) {
 				lv_arc_rotate_obj_to_angle((const lv_obj_t *)_obj, obj_to_rotate, r_offset);
 				return this;
 			}

--- a/src/widgets/Bar.h
+++ b/src/widgets/Bar.h
@@ -1,8 +1,7 @@
 /*
  * Bar.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_BAR_H_
@@ -44,7 +43,7 @@ namespace lvgl {
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -62,7 +61,7 @@ namespace lvgl {
 			 * @param value     new value
 			 * @param anim      LV_ANIM_ON: set the value with an animation; LV_ANIM_OFF: change the value immediately
 			 */
-			inline Bar *setValue(int32_t value, lv_anim_enable_t anim) {
+			inline Bar *SetValue(int32_t value, lv_anim_enable_t anim) {
 				lv_bar_set_value(_obj, value, anim);
 				return this;
 			}
@@ -73,7 +72,7 @@ namespace lvgl {
 			 * @param value     new start value
 			 * @param anim      LV_ANIM_ON: set the value with an animation; LV_ANIM_OFF: change the value immediately
 			 */
-			inline Bar *setStartValue(int32_t start_value, lv_anim_enable_t anim) {
+			inline Bar *SetStartValue(int32_t start_value, lv_anim_enable_t anim) {
 				lv_bar_set_start_value(_obj, start_value,  anim);
 				return this;
 			}
@@ -84,7 +83,7 @@ namespace lvgl {
 			 * @param min       minimum value
 			 * @param max       maximum value
 			 */
-			inline Bar *setRange(int32_t min, int32_t max) {
+			inline Bar *SetRange(int32_t min, int32_t max) {
 				lv_bar_set_range(_obj, min, max);
 				return this;
 			}
@@ -94,7 +93,7 @@ namespace lvgl {
 			 * @param obj       pointer to bar object
 			 * @param mode      bar type from ::lv_bar_mode_t
 			 */
-			inline Bar *setMode(lv_bar_mode_t mode) {
+			inline Bar *SetMode(lv_bar_mode_t mode) {
 				lv_bar_set_mode(_obj,  mode);
 				return this;
 			}
@@ -108,7 +107,7 @@ namespace lvgl {
 			 * @param obj       pointer to a bar object
 			 * @return          the value of the bar
 			 */
-			inline int32_t getValue() {
+			inline int32_t GetValue() {
 				return lv_bar_get_value((const lv_obj_t *)_obj);
 			}
 
@@ -117,7 +116,7 @@ namespace lvgl {
 			 * @param obj       pointer to a bar object
 			 * @return          the start value of the bar
 			 */
-			inline int32_t getStartValue() {
+			inline int32_t GetStartValue() {
 				return lv_bar_get_start_value((const lv_obj_t *)_obj);
 			}
 
@@ -126,7 +125,7 @@ namespace lvgl {
 			 * @param obj       pointer to a bar object
 			 * @return          the minimum value of the bar
 			 */
-			inline int32_t getMinValue() {
+			inline int32_t GetMinValue() {
 				return lv_bar_get_min_value((const lv_obj_t *)_obj);
 			}
 
@@ -135,7 +134,7 @@ namespace lvgl {
 			 * @param obj       pointer to a bar object
 			 * @return          the maximum value of the bar
 			 */
-			inline int32_t getMaxValue() {
+			inline int32_t GetMaxValue() {
 				return lv_bar_get_max_value((const lv_obj_t *)_obj);
 			}
 
@@ -144,7 +143,7 @@ namespace lvgl {
 			 * @param obj       pointer to bar object
 			 * @return          bar type from ::lv_bar_mode_t
 			 */
-			inline lv_bar_mode_t getMode() {
+			inline lv_bar_mode_t GetMode() {
 				return lv_bar_get_mode(_obj);
 			}
 

--- a/src/widgets/Button.h
+++ b/src/widgets/Button.h
@@ -1,8 +1,7 @@
 /*
- * button.h
+ * Button.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_BUTTON_H_
@@ -31,8 +30,8 @@ namespace lvgl {
 			}
 
 			Button(Object *parent) {
-				if(parent && parent->getObj()) {
-					_obj = lv_btn_create(parent->getObj());
+				if(parent && parent->GetObj()) {
+					_obj = lv_btn_create(parent->GetObj());
 				} else {
 					_obj = lv_btn_create(lv_scr_act());
 				}
@@ -54,12 +53,12 @@ namespace lvgl {
 				va_start(args, fmt);
 				vsnprintf(buffer, size + 1, fmt, args);
 				va_end(args);
-				lv_label_set_text(_label->getObj(), buffer);
-				lv_obj_align(_label->getObj(), LV_ALIGN_CENTER, 0, 0);
+				lv_label_set_text(_label->GetObj(), buffer);
+				lv_obj_align(_label->GetObj(), LV_ALIGN_CENTER, 0, 0);
 			}
 
 			Button(Object *parent, char *fmt, ...) {
-				_obj = lv_btn_create(parent->getObj());
+				_obj = lv_btn_create(parent->GetObj());
 				if(fmt == NULL || fmt[0] == 0) {
 					_label = NULL;
 					return;
@@ -73,8 +72,8 @@ namespace lvgl {
 				va_start(args, fmt);
 				vsnprintf(buffer, size + 1, fmt, args);
 				va_end(args);
-				lv_label_set_text(_label->getObj(), buffer);
-				lv_obj_align(_label->getObj(), LV_ALIGN_CENTER, 0, 0);
+				lv_label_set_text(_label->GetObj(), buffer);
+				lv_obj_align(_label->GetObj(), LV_ALIGN_CENTER, 0, 0);
 			}
 			/**
 			 * Create an empty btnMatrix object, this is useful when used as a child.
@@ -92,16 +91,16 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline Button *setObj(lv_obj_t *obj) {
+			inline Button *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
-			inline Label *getLabel() {
+			inline Label *GetLabel() {
 				return _label;
 			}
 			

--- a/src/widgets/ButtonMatrix.h
+++ b/src/widgets/ButtonMatrix.h
@@ -1,8 +1,7 @@
 /*
- * btnMatrix.h
+ * ButtonMatrix.h
  *
- *  Created on: Nov 26, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_BUTTONMATRIX_H_
@@ -44,12 +43,12 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			ButtonMatrix *setObj(lv_obj_t *obj) {
+			ButtonMatrix *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
 
-			lv_obj_t *getObj() {
+			lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -64,7 +63,7 @@ namespace lvgl {
 			 * @param map       pointer a string array. The last string has to be: "". Use "\n" to make a line break.
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setMap(const char * map[]) {
+			inline ButtonMatrix *SetMap(const char * map[]) {
 				lv_btnmatrix_set_map(_obj, map);
 				return this;
 			}
@@ -81,7 +80,7 @@ namespace lvgl {
 			 *                 `ctrl_map[0] = width | LV_BTNMATRIX_CTRL_NO_REPEAT |  LV_BTNMATRIX_CTRL_TGL_ENABLE`
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setCtrlMap(const lv_btnmatrix_ctrl_t ctrl_map[]) {
+			inline ButtonMatrix *SetCtrlMap(const lv_btnmatrix_ctrl_t ctrl_map[]) {
 				lv_btnmatrix_set_ctrl_map(_obj, ctrl_map);
 				return this;
 			}
@@ -90,7 +89,7 @@ namespace lvgl {
 			 * @param btn_id         0 based index of the button to modify. (Not counting new lines)
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setSelectedBtn(uint16_t btn_id) {
+			inline ButtonMatrix *SetSelectedBtn(uint16_t btn_id) {
 				lv_btnmatrix_set_selected_btn(_obj, btn_id);
 				return this;
 			}
@@ -100,7 +99,7 @@ namespace lvgl {
 			 * @param ctrl      OR-ed attributs. E.g. `LV_BTNMATRIX_CTRL_NO_REPEAT | LV_BTNMATRIX_CTRL_CHECKABLE`
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setBtnCtrl(uint16_t btn_id, lv_btnmatrix_ctrl_t ctrl) {
+			inline ButtonMatrix *SetBtnCtrl(uint16_t btn_id, lv_btnmatrix_ctrl_t ctrl) {
 				lv_btnmatrix_set_btn_ctrl(_obj, btn_id, ctrl);
 				return this;
 			}
@@ -119,7 +118,7 @@ namespace lvgl {
 			 * @param ctrl      attribute(s) to set from `lv_btnmatrix_ctrl_t`. Values can be ORed.
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setBtnCtrlAll(lv_btnmatrix_ctrl_t ctrl) {
+			inline ButtonMatrix *SetBtnCtrlAll(lv_btnmatrix_ctrl_t ctrl) {
 				lv_btnmatrix_set_btn_ctrl_all(_obj, ctrl);
 				return this;
 			}
@@ -142,7 +141,7 @@ namespace lvgl {
 			 * @param width     relative width compared to the buttons in the same row. [1..7]
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setBtnWidth(uint16_t btn_id, uint8_t width) {
+			inline ButtonMatrix *SetBtnWidth(uint16_t btn_id, uint8_t width) {
 				lv_btnmatrix_set_btn_width(_obj, btn_id, width);
 				return this;
 			}
@@ -153,7 +152,7 @@ namespace lvgl {
 			 * @param en        whether "one check" mode is enabled
 			 * @return          object pointer
 			 */
-			inline ButtonMatrix *setOneChildren(bool en) {
+			inline ButtonMatrix *SetOneChildren(bool en) {
 				lv_btnmatrix_set_one_checked(_obj, en);
 				return this;
 			}
@@ -165,7 +164,7 @@ namespace lvgl {
 			 * Get the current map of a button matrix
 			 * @return          the current map
 			 */
-			inline const char ** getMap() {
+			inline const char ** GetMap() {
 				return lv_btnmatrix_get_map(_obj);
 			}
 
@@ -174,7 +173,7 @@ namespace lvgl {
 			 * Useful in the `event_cb` to get the text of the button, check if hidden etc.
 			 * @return          index of the last released button (LV_BTNMATRIX_BTN_NONE: if unset)
 			 */
-			inline uint16_t getSelectedBtn() {
+			inline uint16_t GetSelectedBtn() {
 				return lv_btnmatrix_get_selected_btn(_obj);
 			}
 
@@ -183,7 +182,7 @@ namespace lvgl {
 			 * @param btn_id    the index a button not counting new line characters.
 			 * @return          text of btn_index` button
 			 */
-			inline const char *getBtnText(uint16_t btn_id) {
+			inline const char *GetBtnText(uint16_t btn_id) {
 				return lv_btnmatrix_get_btn_text(_obj, btn_id);
 			}
 
@@ -193,7 +192,7 @@ namespace lvgl {
 			 * @param ctrl      control values to check (ORed value can be used)
 			 * @return          true: the control attribute is enabled false: disabled
 			 */
-			inline bool hesBtnCtrl(uint16_t btn_id, lv_btnmatrix_ctrl_t ctrl) {
+			inline bool HasBtnCtrl(uint16_t btn_id, lv_btnmatrix_ctrl_t ctrl) {
 				return lv_btnmatrix_has_btn_ctrl(_obj, btn_id, ctrl);
 			}
 
@@ -201,7 +200,7 @@ namespace lvgl {
 			 * Tell whether "one check" mode is enabled or not.
 			 * @return          true: "one check" mode is enabled; false: disabled
 			 */
-			inline bool getOneChecked() {
+			inline bool GetOneChecked() {
 				return lv_btnmatrix_get_one_checked(_obj);
 			}
 

--- a/src/widgets/Canvas.h
+++ b/src/widgets/Canvas.h
@@ -1,8 +1,7 @@
 /*
  * Canvas.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_CANVAS_H_
@@ -29,7 +28,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -49,7 +48,7 @@ namespace lvgl {
 			 * @param h height of the canvas
 			 * @param cf color format. `LV_IMG_CF_...`
 			 */
-			inline Canvas *setBuffer(void * buf, lv_coord_t w, lv_coord_t h, lv_img_cf_t cf) {
+			inline Canvas *SetBuffer(void * buf, lv_coord_t w, lv_coord_t h, lv_img_cf_t cf) {
 				lv_canvas_set_buffer(_obj, buf, w, h, cf);
 				return this;
 			}
@@ -61,7 +60,7 @@ namespace lvgl {
 			 * @param y x coordinate of the point to set
 			 * @param c color of the pixel
 			 */
-			inline Canvas *setPixelColor(lv_coord_t x, lv_coord_t y, lv_color_t c) {
+			inline Canvas *SetPixelColor(lv_coord_t x, lv_coord_t y, lv_color_t c) {
 				lv_canvas_set_px_color(_obj, x, y, c);
 				return this;
 			}
@@ -69,7 +68,7 @@ namespace lvgl {
 			/**
 			 * DEPRECATED: added only for backward compatibility
 			 */
-			static inline void setPixel(Canvas *inst, lv_coord_t x, lv_coord_t y, lv_color_t c) {
+			static inline void SetPixel(Canvas *inst, lv_coord_t x, lv_coord_t y, lv_color_t c) {
 				lv_canvas_set_px_color(inst->_obj, x, y, c);
 			}
 
@@ -80,7 +79,7 @@ namespace lvgl {
 			 * @param y x coordinate of the point to set
 			 * @param opa opacity of the pixel (0..255)
 			 */
-			inline Canvas *setPixelOpacity(lv_coord_t x, lv_coord_t y, lv_opa_t opa) {
+			inline Canvas *SetPixelOpacity(lv_coord_t x, lv_coord_t y, lv_opa_t opa) {
 				lv_canvas_set_px_opa(_obj, x, y, opa);
 				return this;
 			}
@@ -96,7 +95,7 @@ namespace lvgl {
 			 *   - for `LV_IMG_CF_INDEXED8`: 0..255
 			 * @param c the color to set
 			 */
-			inline Canvas *setPallette(uint8_t id, lv_color_t c) {
+			inline Canvas *SetPallette(uint8_t id, lv_color_t c) {
 				lv_canvas_set_palette(_obj, id, c);
 				return this;
 			}
@@ -112,7 +111,7 @@ namespace lvgl {
 			 * @param y x coordinate of the point to set
 			 * @return color of the point
 			 */
-			inline lv_color_t getPixel(lv_coord_t x, lv_coord_t y) {
+			inline lv_color_t GetPixel(lv_coord_t x, lv_coord_t y) {
 				return lv_canvas_get_px(_obj, x, y);
 			}
 
@@ -121,7 +120,7 @@ namespace lvgl {
 			 * @param canvas pointer to a canvas object
 			 * @return pointer to the image descriptor.
 			 */
-			inline lv_img_dsc_t * getImage() {
+			inline lv_img_dsc_t * GetImage() {
 				return lv_canvas_get_img(_obj);
 			}
 
@@ -139,7 +138,7 @@ namespace lvgl {
 			 * @param w width of the buffer to copy
 			 * @param h height of the buffer to copy
 			 */
-			inline Canvas *copyBuffer(const void * to_copy, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h) {
+			inline Canvas *CopyBuffer(const void * to_copy, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h) {
 				lv_canvas_copy_buf(_obj, to_copy, x, y, w, h);
 				return this;
 			}
@@ -159,7 +158,7 @@ namespace lvgl {
 			 *                Set to `source height / 2` to rotate around the center
 			 * @param antialias apply anti-aliasing during the transformation. Looks better but slower.
 			 */
-			inline Canvas *transform(lv_img_dsc_t * img, int16_t angle, uint16_t zoom, lv_coord_t offset_x,
+			inline Canvas *Transform(lv_img_dsc_t * img, int16_t angle, uint16_t zoom, lv_coord_t offset_x,
 				    lv_coord_t offset_y,
 				    int32_t pivot_x, int32_t pivot_y, bool antialias) {
 				lv_canvas_transform(_obj, img, angle, zoom, offset_x, offset_y, pivot_x, pivot_y, antialias);
@@ -172,7 +171,7 @@ namespace lvgl {
 			 * @param area the area to blur. If `NULL` the whole canvas will be blurred.
 			 * @param r radius of the blur
 			 */
-			inline Canvas *blurHorizontal(const lv_area_t * area, uint16_t r) {
+			inline Canvas *BlurHorizontal(const lv_area_t * area, uint16_t r) {
 				lv_canvas_blur_hor(_obj, area, r);
 				return this;
 			}
@@ -183,7 +182,7 @@ namespace lvgl {
 			 * @param area the area to blur. If `NULL` the whole canvas will be blurred.
 			 * @param r radius of the blur
 			 */
-			inline Canvas *blurVertical(const lv_area_t * area, uint16_t r) {
+			inline Canvas *BlurVertical(const lv_area_t * area, uint16_t r) {
 				lv_canvas_blur_ver(_obj, area, r);
 				return this;
 			}
@@ -194,7 +193,7 @@ namespace lvgl {
 			 * @param color the background color
 			 * @param opa the desired opacity
 			 */
-			inline Canvas *fillBackground(lv_color_t color, lv_opa_t opa) {
+			inline Canvas *FillBackground(lv_color_t color, lv_opa_t opa) {
 				lv_canvas_fill_bg(_obj, color, opa);
 				return this;
 			}
@@ -208,15 +207,13 @@ namespace lvgl {
 			 * @param h        height of the rectangle
 			 * @param draw_dsc descriptor of the rectangle
 			 */
-			inline Canvas *drawRectangle(lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h,
-				    const lv_draw_rect_dsc_t * draw_dsc) {
+			inline Canvas *DrawRectangle(lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h, const lv_draw_rect_dsc_t * draw_dsc) {
 				lv_canvas_draw_rect(_obj, x, y, w, h, draw_dsc);
 				return this;
 			}
 
-			inline Canvas *drawRectangle(lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h,
-				    lvgl::draw::Rectangle *rectangle) {
-				lv_canvas_draw_rect(_obj, x, y, w, h, rectangle->get());
+			inline Canvas *DrawRectangle(lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h, lvgl::draw::Rectangle *rectangle) {
+				lv_canvas_draw_rect(_obj, x, y, w, h, rectangle->Get());
 				return this;
 			}
 
@@ -229,7 +226,7 @@ namespace lvgl {
 			 * @param draw_dsc pointer to a valid label descriptor `lv_draw_label_dsc_t`
 			 * @param txt      text to display
 			 */
-			inline Canvas *drawText(lv_coord_t x, lv_coord_t y, lv_coord_t max_w,
+			inline Canvas *DrawText(lv_coord_t x, lv_coord_t y, lv_coord_t max_w,
 				    lv_draw_label_dsc_t * draw_dsc, const char * txt) {
 				lv_canvas_draw_text(_obj, x, y, max_w, draw_dsc,  txt);
 				return this;
@@ -243,7 +240,7 @@ namespace lvgl {
 			 * @param src      image source. Can be a pointer an `lv_img_dsc_t` variable or a path an image.
 			 * @param draw_dsc pointer to a valid label descriptor `lv_draw_img_dsc_t`
 			 */
-			inline Canvas *drawImage(lv_coord_t x, lv_coord_t y, const void * src,
+			inline Canvas *DrawImage(lv_coord_t x, lv_coord_t y, const void * src,
 				    const lv_draw_img_dsc_t * draw_dsc) {
 				lv_canvas_draw_img(_obj, x, y, src, draw_dsc);
 				return this;
@@ -256,7 +253,7 @@ namespace lvgl {
 			 * @param point_cnt  number of points
 			 * @param draw_dsc   pointer to an initialized `lv_draw_line_dsc_t` variable
 			 */
-			inline Canvas *drawLine(const lv_point_t points[], uint32_t point_cnt,
+			inline Canvas *DrawLine(const lv_point_t points[], uint32_t point_cnt,
 				    const lv_draw_line_dsc_t * draw_dsc) {
 				lv_canvas_draw_line(_obj, points, point_cnt, draw_dsc);
 				return this;
@@ -269,7 +266,7 @@ namespace lvgl {
 			 * @param point_cnt number of points
 			 * @param draw_dsc  pointer to an initialized `lv_draw_rect_dsc_t` variable
 			 */
-			inline Canvas *drawPolygon(const lv_point_t points[], uint32_t point_cnt,
+			inline Canvas *DrawPolygon(const lv_point_t points[], uint32_t point_cnt,
 				    const lv_draw_rect_dsc_t * draw_dsc) {
 				lv_canvas_draw_polygon(_obj, points, point_cnt, draw_dsc);
 				return this;
@@ -285,7 +282,7 @@ namespace lvgl {
 			 * @param end_angle   end angle in degrees
 			 * @param draw_dsc    pointer to an initialized `lv_draw_line_dsc_t` variable
 			 */
-			inline Canvas *drawArc(lv_coord_t x, lv_coord_t y, lv_coord_t r, int32_t start_angle,
+			inline Canvas *DrawArc(lv_coord_t x, lv_coord_t y, lv_coord_t r, int32_t start_angle,
 				    int32_t end_angle, const lv_draw_arc_dsc_t * draw_dsc) {
 				lv_canvas_draw_arc(_obj, x, y, r, start_angle, end_angle, draw_dsc);
 				return this;

--- a/src/widgets/CheckBox.h
+++ b/src/widgets/CheckBox.h
@@ -1,8 +1,7 @@
 /*
  * CheckBox.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_CHECKBOX_H_
@@ -27,7 +26,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -41,7 +40,7 @@ namespace lvgl {
 			 * @param cb    pointer to a check box
 			 * @param txt   the text of the check box. NULL to refresh with the current text.
 			 */
-			inline CheckBox *setText(const char * txt) {
+			inline CheckBox *SetText(const char * txt) {
 				lv_checkbox_set_text(_obj, txt);
 				return this;
 			}
@@ -52,7 +51,7 @@ namespace lvgl {
 			 * @param cb    pointer to a check box
 			 * @param txt   the text of the check box.
 			 */
-			inline CheckBox *setTextStatic(const char * txt) {
+			inline CheckBox *SetTextStatic(const char * txt) {
 				lv_checkbox_set_text_static(_obj, txt);
 				return this;
 			}

--- a/src/widgets/DropDown.h
+++ b/src/widgets/DropDown.h
@@ -1,8 +1,7 @@
 /*
  * DropDown.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_DROPDOWN_H_
@@ -40,10 +39,10 @@ namespace lvgl {
 			}
 			DropDown(Object *parent, const char *options) {
 				if(options == NULL) {
-					_obj = parent->getObj();
+					_obj = parent->GetObj();
 				} else {
-					if(parent && parent->getObj()) {
-						_obj = lv_dropdown_create(parent->getObj());
+					if(parent && parent->GetObj()) {
+						_obj = lv_dropdown_create(parent->GetObj());
 					} else {
 						_obj = lv_dropdown_create(lv_scr_act());
 					}
@@ -56,7 +55,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -71,7 +70,7 @@ namespace lvgl {
 			 * @param obj       pointer to a drop-down list object
 			 * @param txt       the text as a string (Only its pointer is saved)
 			 */
-			inline DropDown *setText(const char * txt) {
+			inline DropDown *SetText(const char * txt) {
 				lv_dropdown_set_text(_obj, txt);
 				return this;
 			}
@@ -82,7 +81,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @param options   a string with '\n' separated options. E.g. "One\nTwo\nThree"
 			 */
-			inline DropDown *setOptions(const char * options) {
+			inline DropDown *SetOptions(const char * options) {
 				lv_dropdown_set_options(_obj, options);
 				return this;
 			}
@@ -93,7 +92,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @param options   a static string with '\n' separated options. E.g. "One\nTwo\nThree"
 			 */
-			inline DropDown *setOptionsStatic(const char * options) {
+			inline DropDown *SetOptionsStatic(const char * options) {
 				lv_dropdown_set_options_static(_obj, options);
 				return this;
 			}
@@ -104,7 +103,7 @@ namespace lvgl {
 			 * @param option    a string without '\n'. E.g. "Four"
 			 * @param pos       the insert position, indexed from 0, LV_DROPDOWN_POS_LAST = end of string
 			 */
-			inline DropDown *addOptions(const char * option, uint32_t pos) {
+			inline DropDown *AddOptions(const char * option, uint32_t pos) {
 				lv_dropdown_add_option(_obj, option, pos);
 				return this;
 			}
@@ -113,7 +112,7 @@ namespace lvgl {
 			 * Clear all options in a drop-down list.  Works with both static and dynamic options.
 			 * @param obj       pointer to drop-down list object
 			 */
-			inline DropDown *clearOptions() {
+			inline DropDown *ClearOptions() {
 				lv_dropdown_clear_options(_obj);
 				return this;
 			}
@@ -123,7 +122,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @param sel_opt   id of the selected option (0 ... number of option - 1);
 			 */
-			inline DropDown *setSelected(uint16_t sel_opt) {
+			inline DropDown *SetSelected(uint16_t sel_opt) {
 				lv_dropdown_set_selected(_obj, sel_opt);
 				return this;
 			}
@@ -133,7 +132,7 @@ namespace lvgl {
 			 * @param obj       pointer to a drop-down list object
 			 * @param dir       LV_DIR_LEFT/RIGHT/TOP/BOTTOM
 			 */
-			inline DropDown *setDirection(lv_dir_t dir) {
+			inline DropDown *SetDirection(lv_dir_t dir) {
 				lv_dropdown_set_dir(_obj, dir);
 				return this;
 			}
@@ -145,7 +144,7 @@ namespace lvgl {
 			 * @note angle and zoom transformation can be applied if the symbol is an image.
 			 * E.g. when drop down is checked (opened) rotate the symbol by 180 degree
 			 */
-			inline DropDown *setSymbol(const void * symbol) {
+			inline DropDown *SetSymbol(const void * symbol) {
 				lv_dropdown_set_symbol(_obj, symbol);
 				return this;
 			}
@@ -155,7 +154,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @param en        true: highlight enabled; false: disabled
 			 */
-			inline DropDown *setSelectedHighlight(bool en) {
+			inline DropDown *SetSelectedHighlight(bool en) {
 				lv_dropdown_set_selected_highlight(_obj, en);
 				return this;
 			}
@@ -169,7 +168,7 @@ namespace lvgl {
 			 * @param obj       pointer to a drop-down list object
 			 * @return          pointer to the list of the drop-down
 			 */
-			inline lv_obj_t *getList() {
+			inline lv_obj_t *GetList() {
 				return lv_dropdown_get_list(_obj);
 			}
 
@@ -178,7 +177,7 @@ namespace lvgl {
 			 * @param obj   pointer to a drop-down list object
 			 * @return      the text as string, `NULL` if no text
 			 */
-			inline const char *getText() {
+			inline const char *GetText() {
 				return lv_dropdown_get_text(_obj);
 			}
 
@@ -187,7 +186,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @return          the options separated by '\n'-s (E.g. "Option1\nOption2\nOption3")
 			 */
-			inline const char *getOptions() {
+			inline const char *GetOptions() {
 				return lv_dropdown_get_options(_obj);
 			}
 
@@ -196,11 +195,11 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @return          index of the selected option (0 ... number of option - 1);
 			 */
-			inline uint16_t getSelected() {
+			inline uint16_t GetSelected() {
 				return lv_dropdown_get_selected(_obj);
 			}
 
-			static inline uint16_t getSelected(lv_obj_t *obj) {
+			static inline uint16_t GetSelected(lv_obj_t *obj) {
 				return lv_dropdown_get_selected(obj);
 			}
 
@@ -209,7 +208,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @return          the total number of options in the list
 			 */
-			inline uint16_t getOptionCnt() {
+			inline uint16_t GetOptionCnt() {
 				return lv_dropdown_get_option_cnt(_obj);
 			}
 
@@ -219,12 +218,12 @@ namespace lvgl {
 			 * @param buf       pointer to an array to store the string
 			 * @param buf_size  size of `buf` in bytes. 0: to ignore it.
 			 */
-			inline DropDown *getSelectedStr( char * buf, uint32_t buf_size) {
+			inline DropDown *GetSelectedStr( char * buf, uint32_t buf_size) {
 				lv_dropdown_get_selected_str(_obj, buf, buf_size);
 				return this;
 			}
 
-			static inline void getSelectedStr(lv_obj_t *obj, char * buf, uint32_t buf_size) {
+			static inline void GetSelectedStr(lv_obj_t *obj, char * buf, uint32_t buf_size) {
 				lv_dropdown_get_selected_str(obj, buf, buf_size);
 			}
 
@@ -234,7 +233,7 @@ namespace lvgl {
 			 * @param option    an option as string
 			 * @return          index of `option` in the list of all options. -1 if not found.
 			 */
-			inline int32_t getOptionIndex(const char * option) {
+			inline int32_t GetOptionIndex(const char * option) {
 				return lv_dropdown_get_option_index(_obj, option);
 			}
 
@@ -243,7 +242,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @return          the symbol or NULL if not enabled
 			 */
-			inline const char *getSymbol() {
+			inline const char *GetSymbol() {
 				return lv_dropdown_get_symbol(_obj);
 			}
 
@@ -252,7 +251,7 @@ namespace lvgl {
 			 * @param obj       pointer to drop-down list object
 			 * @return          true: highlight enabled; false: disabled
 			 */
-			inline bool getSelectedHighlight() {
+			inline bool GetSelectedHighlight() {
 				return lv_dropdown_get_selected_highlight(_obj);
 			}
 
@@ -261,7 +260,7 @@ namespace lvgl {
 			 * @param obj       pointer to a drop-down list object
 			 * @return          LV_DIR_LEF/RIGHT/TOP/BOTTOM
 			 */
-			inline lv_dir_t getDirection() {
+			inline lv_dir_t GetDirection() {
 				return lv_dropdown_get_dir(_obj);
 			}
 

--- a/src/widgets/Image.h
+++ b/src/widgets/Image.h
@@ -1,8 +1,7 @@
 /*
  * Image.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_IMAGE_H_
@@ -27,7 +26,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -42,7 +41,7 @@ namespace lvgl {
 			 *                  2) path to an image file (e.g. "S:/dir/img.bin")or
 			 *                  3) a SYMBOL (e.g. LV_SYMBOL_OK)
 			 */
-			inline Image *setSource(const void *src) {
+			inline Image *SetSource(const void *src) {
 				lv_img_set_src(_obj, src);
 				return this;
 			}
@@ -52,7 +51,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image
 			 * @param x         the new offset along x axis.
 			 */
-			inline Image *setOffset(lv_coord_t x, lv_coord_t y) {
+			inline Image *SetOffset(lv_coord_t x, lv_coord_t y) {
 				lv_img_set_offset_x(_obj, x);
 				lv_img_set_offset_y(_obj, y);
 				return this;
@@ -63,7 +62,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image
 			 * @param x         the new offset along x axis.
 			 */
-			inline Image *setOffsetX(lv_coord_t x) {
+			inline Image *SetOffsetX(lv_coord_t x) {
 				lv_img_set_offset_x(_obj, x);
 				return this;
 			}
@@ -74,7 +73,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image
 			 * @param y         the new offset along y axis.
 			 */
-			inline Image *setOffsetY(lv_coord_t y) {
+			inline Image *SetOffsetY(lv_coord_t y) {
 				lv_img_set_offset_y(_obj, y);
 				return this;
 			}
@@ -87,7 +86,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @param angle     rotation angle in degree with 0.1 degree resolution (0..3600: clock wise)
 			 */
-			inline Image *setAngle(int16_t angle) {
+			inline Image *SetAngle(int16_t angle) {
 				lv_img_set_angle(_obj, angle);
 				return this;
 			}
@@ -99,7 +98,7 @@ namespace lvgl {
 			 * @param x         rotation center x of the image
 			 * @param y         rotation center y of the image
 			 */
-			inline Image *setPivot(lv_coord_t x, lv_coord_t y) {
+			inline Image *SetPivot(lv_coord_t x, lv_coord_t y) {
 				lv_img_set_pivot(_obj, x, y);
 				return this;
 			}
@@ -116,7 +115,7 @@ namespace lvgl {
 			 * @example 128 half size
 			 * @example 512 double size
 			 */
-			inline Image *setZoom(uint16_t zoom) {
+			inline Image *SetZoom(uint16_t zoom) {
 				lv_img_set_zoom(_obj, zoom);
 				return this;
 			}
@@ -127,7 +126,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @param antialias true: anti-aliased; false: not anti-aliased
 			 */
-			inline Image *setAntiAlias(bool antialias) {
+			inline Image *SetAntiAlias(bool antialias) {
 				lv_img_set_antialias(_obj, antialias);
 				return this;
 			}
@@ -138,7 +137,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @param mode      the new size mode.
 			 */
-			inline Image *setSizeMode(lv_img_size_mode_t mode) {
+			inline Image *SetSizeMode(lv_img_size_mode_t mode) {
 				lv_img_set_size_mode(_obj, mode);
 				return this;
 			}
@@ -151,7 +150,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @return          the image source (symbol, file name or ::lv-img_dsc_t for C arrays)
 			 */
-			inline const void *getSource() {
+			inline const void *GetSource() {
 				return lv_img_get_src(_obj);
 			}
 
@@ -160,7 +159,7 @@ namespace lvgl {
 			 * @param img       pointer to an image
 			 * @return          offset X value.
 			 */
-			inline lv_coord_t getOffsetX() {
+			inline lv_coord_t GetOffsetX() {
 				return lv_img_get_offset_x(_obj);
 			}
 
@@ -169,7 +168,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image
 			 * @return          offset Y value.
 			 */
-			inline lv_coord_t getOffsetY() {
+			inline lv_coord_t GetOffsetY() {
 				return lv_img_get_offset_y(_obj);
 			}
 
@@ -178,7 +177,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @return      rotation angle in 0.1 degrees (0..3600)
 			 */
-			inline uint16_t getAngle() {
+			inline uint16_t GetAngle() {
 				return lv_img_get_angle(_obj);
 			}
 
@@ -187,7 +186,7 @@ namespace lvgl {
 			 * @param img       pointer to an image object
 			 * @param pivot     store the rotation center here
 			 */
-			inline lv_point_t getPivot() {
+			inline lv_point_t GetPivot() {
 				lv_point_t pivot;
 				lv_img_get_pivot(_obj, &pivot);
 				return pivot;
@@ -198,7 +197,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @return          zoom factor (256: no zoom)
 			 */
-			inline uint16_t getZoom() {
+			inline uint16_t GetZoom() {
 				return lv_img_get_zoom(_obj);
 			}
 
@@ -207,7 +206,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @return          true: anti-aliased; false: not anti-aliased
 			 */
-			inline bool getAntialias() {
+			inline bool GetAntialias() {
 				return lv_img_get_antialias(_obj);
 			}
 
@@ -216,7 +215,7 @@ namespace lvgl {
 			 * @param obj       pointer to an image object
 			 * @return          element of @ref lv_img_size_mode_t
 			 */
-			inline lv_img_size_mode_t getSizeMode() {
+			inline lv_img_size_mode_t GetSizeMode() {
 				return lv_img_get_size_mode(_obj);
 			}
 

--- a/src/widgets/Label.h
+++ b/src/widgets/Label.h
@@ -1,8 +1,7 @@
 /*
  * Label.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_LABEL_H_
@@ -39,8 +38,8 @@ namespace lvgl {
 			 * @return          pointer to the created button matrix
 			 */
 			Label(Object *parent) {
-				if(parent && parent->getObj()) {
-					_obj = lv_label_create(parent->getObj());
+				if(parent && parent->GetObj()) {
+					_obj = lv_label_create(parent->GetObj());
 				} else {
 					_obj = lv_label_create(lv_scr_act());
 				}
@@ -54,8 +53,8 @@ namespace lvgl {
 			 * @return          pointer to the created button matrix
 			 */
 			/*Label(Object parent) {
-				if(parent && parent.getObj()) {
-					_obj = lv_label_create(parent.getObj());
+				if(parent && parent.GetObj()) {
+					_obj = lv_label_create(parent.GetObj());
 				} else {
 					_obj = lv_label_create(lv_scr_act());
 				}
@@ -83,8 +82,8 @@ namespace lvgl {
 			}
 
 			Label(Object *parent, char *fmt, ...) {
-				if(parent && parent->getObj()) {
-					_obj = lv_label_create(parent->getObj());
+				if(parent && parent->GetObj()) {
+					_obj = lv_label_create(parent->GetObj());
 				} else {
 					_obj = lv_label_create(lv_scr_act());
 				}
@@ -102,8 +101,8 @@ namespace lvgl {
 			}
 
 			/*Label(Object parent, char *fmt, ...) {
-				if(parent && parent.getObj()) {
-					_obj = lv_label_create(parent.getObj());
+				if(parent && parent.GetObj()) {
+					_obj = lv_label_create(parent.GetObj());
 				} else {
 					_obj = lv_label_create(lv_scr_act());
 				}
@@ -135,12 +134,12 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline Label *setObj(lv_obj_t *obj) {
+			inline Label *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -154,7 +153,7 @@ namespace lvgl {
 			 * @param obj           pointer to a Label object
 			 * @param text          '\0' terminated character string. NULL to refresh with the current text.
 			 */
-			inline Label *setText(const char * text) {
+			inline Label *SetText(const char * text) {
 				lv_label_set_text(_obj, text);
 				return this;
 			}
@@ -165,7 +164,7 @@ namespace lvgl {
 			 * @param fmt           `printf`-like format
 			 * @example lv_label_set_text_fmt(label1, "%d user", user_num);
 			 */
-			inline Label *setText(const char * fmt, ...) {
+			inline Label *SetText(const char * fmt, ...) {
 				va_list args;
 				va_start(args, fmt);
 				int size = vsnprintf(NULL, 0, fmt, args);
@@ -184,7 +183,7 @@ namespace lvgl {
 			 * @param obj           pointer to a Label object
 			 * @param text          pointer to a text. NULL to refresh with the current text.
 			 */
-			inline Label *setTextStatic(const char * text) {
+			inline Label *SetTextStatic(const char * text) {
 				lv_label_set_text_static(_obj, text);
 				return this;
 			}
@@ -195,7 +194,7 @@ namespace lvgl {
 			 * @param long_mode     the new mode from 'lv_label_long_mode' enum.
 			 *                      In LV_LONG_WRAP/DOT/SCROLL/SCROLL_CIRC the size of the Label should be set AFTER this function
 			 */
-			inline Label *setLongMode(lv_label_long_mode_t long_mode) {
+			inline Label *SetLongMode(lv_label_long_mode_t long_mode) {
 				lv_label_set_long_mode(_obj, long_mode);
 				return this;
 			}
@@ -206,7 +205,7 @@ namespace lvgl {
 			 * @param en            true: enable recoloring, false: disable
 			 * @example "This is a #ff0000 red# word"
 			 */
-			inline Label *setReColor(bool en) {
+			inline Label *SetReColor(bool en) {
 				lv_label_set_recolor(_obj, en);
 				return this;
 			}
@@ -216,7 +215,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object
 			 * @param index     character index from where selection should start. `LV_LABEL_TEXT_SELECTION_OFF` for no selection
 			 */
-			inline Label *setTextSelkStart(uint32_t index) {
+			inline Label *SetTextSelkStart(uint32_t index) {
 				lv_label_set_text_sel_start(_obj, index);
 				return this;
 			}
@@ -226,7 +225,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object
 			 * @param index     character index where selection should end. `LV_LABEL_TEXT_SELECTION_OFF` for no selection
 			 */
-			inline Label *setTextSelEnd(uint32_t index) {
+			inline Label *SetTextSelEnd(uint32_t index) {
 				lv_label_set_text_sel_end(_obj, index);
 				return this;
 			}
@@ -240,7 +239,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object
 			 * @return          the text of the Label
 			 */
-			inline char *getText() {
+			inline char *GetText() {
 				return lv_label_get_text(_obj);
 			}
 
@@ -249,7 +248,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object
 			 * @return          the current long mode
 			 */
-			inline lv_label_long_mode_t getLongMode() {
+			inline lv_label_long_mode_t GetLongMode() {
 				return lv_label_get_long_mode(_obj);
 			}
 
@@ -258,7 +257,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object
 			 * @return          true: recoloring is enabled, false: disable
 			 */
-			inline bool getReColor() {
+			inline bool GetReColor() {
 				return lv_label_get_recolor(_obj);
 			}
 
@@ -269,7 +268,7 @@ namespace lvgl {
 			 *                  Expressed in character index, not byte index (different in UTF-8)
 			 * @param pos       store the result here (E.g. index = 0 gives 0;0 coordinates if the text if aligned to the left)
 			 */
-			inline Label *getLetter(uint32_t char_id, lv_point_t * pos) {
+			inline Label *GetLetter(uint32_t char_id, lv_point_t * pos) {
 				lv_label_get_letter_pos(_obj, char_id, pos);
 				return this;
 			}
@@ -281,7 +280,7 @@ namespace lvgl {
 			 * @return          The index of the letter on the 'pos_p' point (E.g. on 0;0 is the 0. letter if aligned to the left)
 			 *                  Expressed in character index and not byte index (different in UTF-8)
 			 */
-			inline uint32_t getLetterOn(lv_point_t * pos_in) {
+			inline uint32_t GetLetterOn(lv_point_t * pos_in) {
 				return lv_label_get_letter_on(_obj, pos_in);
 			}
 
@@ -291,7 +290,7 @@ namespace lvgl {
 			 * @param pos       Point to check for character under
 			 * @return          whether a character is drawn under the point
 			 */
-			inline bool isCharUnderPos(lv_point_t * pos) {
+			inline bool IsCharUnderPos(lv_point_t * pos) {
 				return lv_label_is_char_under_pos(_obj, pos);
 			}
 
@@ -300,7 +299,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object.
 			 * @return          selection start index. `LV_LABEL_TEXT_SELECTION_OFF` if nothing is selected.
 			 */
-			inline uint32_t getTextSelectionStart() {
+			inline uint32_t GetTextSelectionStart() {
 				return lv_label_get_text_selection_start(_obj);
 			}
 
@@ -309,7 +308,7 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object.
 			 * @return          selection end index. `LV_LABEL_TXT_SEL_OFF` if nothing is selected.
 			 */
-			inline uint32_t getTextSelectionEnd() {
+			inline uint32_t GetTextSelectionEnd() {
 				return lv_label_get_text_selection_end(_obj);
 			}
 

--- a/src/widgets/Line.h
+++ b/src/widgets/Line.h
@@ -1,8 +1,7 @@
 /*
- * line.h
+ * Line.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_LINE_H_
@@ -28,7 +27,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -42,7 +41,7 @@ namespace lvgl {
 			 * @param points        an array of points. Only the address is saved, so the array needs to be alive while the line exists
 			 * @param point_num     number of points in 'point_a'
 			 */
-			inline Line *setPoints(const lv_point_t points[], uint16_t point_num) {
+			inline Line *SetPoints(const lv_point_t points[], uint16_t point_num) {
 				lv_line_set_points(_obj, points, point_num);
 				return this;
 			}
@@ -54,7 +53,7 @@ namespace lvgl {
 			 * @param obj       pointer to a line object
 			 * @param en        true: enable the y inversion, false:disable the y inversion
 			 */
-			inline Line *setYInvert(bool en) {
+			inline Line *SetYInvert(bool en) {
 				lv_line_set_y_invert(_obj, en);
 				return this;
 			}
@@ -68,7 +67,7 @@ namespace lvgl {
 			 * @param obj       pointer to a line object
 			 * @return          true: y inversion is enabled, false: disabled
 			 */
-			inline bool getYInvert() {
+			inline bool GetYInvert() {
 				return lv_line_get_y_invert((const lv_obj_t *)_obj);
 			}
 

--- a/src/widgets/List.h
+++ b/src/widgets/List.h
@@ -1,3 +1,8 @@
+/*
+ * List.h
+ *
+ *      Author: Iulian Gheorghiu
+ */
 #ifndef LVGLCPP_SRC_LIST_H_
 #define LVGLCPP_SRC_LIST_H_
 
@@ -37,12 +42,12 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline List *setObj(lv_obj_t *obj) {
+			inline List *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -80,7 +85,7 @@ namespace lvgl {
 				vsnprintf(buffer, size + 1, fmt, args);
 				va_end(args);
 				Label label;
-				label.setObj(lv_list_add_text(_obj, buffer));
+				label.SetObj(lv_list_add_text(_obj, buffer));
 				return label;
 			}
 
@@ -108,30 +113,30 @@ namespace lvgl {
 				vsnprintf(buffer, size + 1, fmt, args);
 				va_end(args);
 				Button btn;
-				btn.setObj(lv_list_add_btn(_obj, icon, buffer));
+				btn.SetObj(lv_list_add_btn(_obj, icon, buffer));
 				return btn;
 			}
 			
-			inline List *setBtnText(Button * btn, const char * text) {
-				if(!btn || !btn->getObj() || !text)
+			inline List *SetBtnText(Button * btn, const char * text) {
+				if(!btn || !btn->GetObj() || !text)
 					return this;
 				uint32_t i;
-				for(i = 0; i < lv_obj_get_child_cnt(btn->getObj()); i++) {
-					lv_obj_t * child = lv_obj_get_child(btn->getObj(), i);
+				for(i = 0; i < lv_obj_get_child_cnt(btn->GetObj()); i++) {
+					lv_obj_t * child = lv_obj_get_child(btn->GetObj(), i);
 					if(lv_obj_check_type(child, &lv_label_class)) {
 						lv_label_set_text(child, text);
 						return this;
 					}
 				}
-				lv_obj_t * label = lv_label_create(btn->getObj());
+				lv_obj_t * label = lv_label_create(btn->GetObj());
 				lv_label_set_text(label, text);
 				lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
 				lv_obj_set_flex_grow(label, 1);
 				return this;
 			}
 
-			void setBtnText(Button * btn, const char *fmt, ...) {
-				if(!btn || !btn->getObj() || !fmt)
+			void SetBtnText(Button * btn, const char *fmt, ...) {
+				if(!btn || !btn->GetObj() || !fmt)
 					return;
 				va_list args;
 				va_start(args, fmt);
@@ -143,56 +148,56 @@ namespace lvgl {
 				va_end(args);
 
 				uint32_t i;
-				for(i = 0; i < lv_obj_get_child_cnt(btn->getObj()); i++) {
-					lv_obj_t * child = lv_obj_get_child(btn->getObj(), i);
+				for(i = 0; i < lv_obj_get_child_cnt(btn->GetObj()); i++) {
+					lv_obj_t * child = lv_obj_get_child(btn->GetObj(), i);
 					if(lv_obj_check_type(child, &lv_label_class)) {
 						lv_label_set_text(child, buffer);
 						return;
 					}
 				}
-				lv_obj_t * label = lv_label_create(btn->getObj());
+				lv_obj_t * label = lv_label_create(btn->GetObj());
 				lv_label_set_text(label, buffer);
 				lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
 				lv_obj_set_flex_grow(label, 1);
 			}
 
-			void setBtnImg(Button * btn, const void * icon) {
-				if(!btn || !btn->getObj() || !icon)
+			void SetBtnImg(Button * btn, const void * icon) {
+				if(!btn || !btn->GetObj() || !icon)
 					return;
 				uint32_t i;
-				for(i = 0; i < lv_obj_get_child_cnt(btn->getObj()); i++) {
-					lv_obj_t * child = lv_obj_get_child(btn->getObj(), i);
+				for(i = 0; i < lv_obj_get_child_cnt(btn->GetObj()); i++) {
+					lv_obj_t * child = lv_obj_get_child(btn->GetObj(), i);
 					if(lv_obj_check_type(child, &lv_img_class)) {
 						lv_img_set_src(child, icon);
 						return;
 					}
 				}
-				lv_obj_t * img = lv_img_create(btn->getObj());
+				lv_obj_t * img = lv_img_create(btn->GetObj());
 				lv_img_set_src(img, icon);
 			}
 
-			void setBtnImgText(Button * btn, const void * icon, const char *text) {
-				if(!btn || !btn->getObj() || !icon || !text)
+			void SetBtnImgText(Button * btn, const void * icon, const char *text) {
+				if(!btn || !btn->GetObj() || !icon || !text)
 					return;
-				setBtnImg(btn, icon);
+				SetBtnImg(btn, icon);
 				uint32_t i;
-				for(i = 0; i < lv_obj_get_child_cnt(btn->getObj()); i++) {
-					lv_obj_t * child = lv_obj_get_child(btn->getObj(), i);
+				for(i = 0; i < lv_obj_get_child_cnt(btn->GetObj()); i++) {
+					lv_obj_t * child = lv_obj_get_child(btn->GetObj(), i);
 					if(lv_obj_check_type(child, &lv_label_class)) {
 						lv_label_set_text(child, text);
 						return;
 					}
 				}
-				lv_obj_t * label = lv_label_create(btn->getObj());
+				lv_obj_t * label = lv_label_create(btn->GetObj());
 				lv_label_set_text(label, text);
 				lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
 				lv_obj_set_flex_grow(label, 1);
 			}
 
-			void setBtnImgText(Button * btn, const void * icon, const char *fmt, ...) {
-				if(!btn || !btn->getObj() || !icon || !fmt)
+			void SetBtnImgText(Button * btn, const void * icon, const char *fmt, ...) {
+				if(!btn || !btn->GetObj() || !icon || !fmt)
 					return;
-				setBtnImg(btn, icon);
+				SetBtnImg(btn, icon);
 				va_list args;
 				va_start(args, fmt);
 				int size = vsnprintf(NULL, 0, fmt, args);
@@ -203,14 +208,14 @@ namespace lvgl {
 				va_end(args);
 
 				uint32_t i;
-				for(i = 0; i < lv_obj_get_child_cnt(btn->getObj()); i++) {
-					lv_obj_t * child = lv_obj_get_child(btn->getObj(), i);
+				for(i = 0; i < lv_obj_get_child_cnt(btn->GetObj()); i++) {
+					lv_obj_t * child = lv_obj_get_child(btn->GetObj(), i);
 					if(lv_obj_check_type(child, &lv_label_class)) {
 						lv_label_set_text(child, buffer);
 						return;
 					}
 				}
-				lv_obj_t * label = lv_label_create(btn->getObj());
+				lv_obj_t * label = lv_label_create(btn->GetObj());
 				lv_label_set_text(label, buffer);
 				lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
 				lv_obj_set_flex_grow(label, 1);
@@ -225,8 +230,8 @@ namespace lvgl {
 			 * @param obj       pointer to a Label object
 			 * @return          the text of the Label
 			 */
-			inline const char *getBtnText(Button * btn) {
-				return lv_list_get_btn_text(_obj, btn->getObj());
+			inline const char *GetBtnText(Button * btn) {
+				return lv_list_get_btn_text(_obj, btn->GetObj());
 			}
 
 		};

--- a/src/widgets/MsgBox.h
+++ b/src/widgets/MsgBox.h
@@ -1,3 +1,8 @@
+/*
+ * MsgBox.h
+ *
+ *      Author: Iulian Gheorghiu
+ */
 #ifndef LVGLCPP_SRC_MSGBOX_H_
 #define LVGLCPP_SRC_MSGBOX_H_
 
@@ -35,12 +40,12 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline MsgBox *setObj(lv_obj_t *obj) {
+			inline MsgBox *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -56,35 +61,35 @@ namespace lvgl {
 			 * Getter functions
 			 *====================*/
 			 
-			 inline Label getTitle() {
+			 inline Label GetTitle() {
 				Label label;
-				label.setObj(lv_msgbox_get_title(_obj));
+				label.SetObj(lv_msgbox_get_title(_obj));
 				return label;
 			 }
 
-			 inline Button getCloseBtn() {
+			 inline Button GetCloseBtn() {
 				Button button;
-				button.setObj(lv_msgbox_get_close_btn(_obj));
+				button.SetObj(lv_msgbox_get_close_btn(_obj));
 				return button;
 			 }
 
-			 inline Label getText() {
+			 inline Label GetText() {
 				Label label;
-				label.setObj(lv_msgbox_get_text(_obj));
+				label.SetObj(lv_msgbox_get_text(_obj));
 				return label;
 			 }
 
-			 inline ButtonMatrix getBtns() {
+			 inline ButtonMatrix GetBtns() {
 				ButtonMatrix btns;
-				btns.setObj(lv_msgbox_get_btns(_obj));
+				btns.SetObj(lv_msgbox_get_btns(_obj));
 				return btns;
 			 }
 			 
-			 inline uint16_t getActiveBtn() {
+			 inline uint16_t GetActiveBtn() {
 			 	return lv_msgbox_get_active_btn(_obj);
 			 }
 			 
-			 inline const char * getActiveBtnText() {
+			 inline const char * GetActiveBtnText() {
 			 	 return lv_msgbox_get_active_btn_text(_obj);
 			 }
 			 

--- a/src/widgets/Object.h
+++ b/src/widgets/Object.h
@@ -1,8 +1,7 @@
 /*
  * Object.h
  *
- *  Created on: Nov 25, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVCPP_LVOBJ_H_
@@ -33,20 +32,20 @@ namespace lvgl {
 			 * Set the object pointer when used as a child.
 			 */
 			Object(Object *obj) {
-				_obj = lv_obj_create(obj->getObj());
+				_obj = lv_obj_create(obj->GetObj());
 			}
 
 			/**
 			 * Set the object pointer when used as a child.
 			 */
 			/*Object(const Object& obj) {
-				_obj = lv_obj_create(obj.getObj());
+				_obj = lv_obj_create(obj.GetObj());
 			}*/
 
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline Object *setObj(lv_obj_t *obj) {
+			inline Object *SetObj(lv_obj_t *obj) {
 				_obj = obj;
 				return this;
 			}
@@ -54,24 +53,24 @@ namespace lvgl {
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline Object *setObj(Object *obj) {
-				_obj = obj->getObj();
+			inline Object *SetObj(Object *obj) {
+				_obj = obj->GetObj();
 				return this;
 			}
 
 			/**
 			 * Set the object pointer when used as a child.
 			 */
-			inline Object *setObj(Object obj) {
-				_obj = obj.getObj();
+			inline Object *SetObj(Object obj) {
+				_obj = obj.GetObj();
 				return this;
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
-			void setEnabled(bool enable) {
+			void SetEnabled(bool enable) {
 				if (enable) {
 					lv_obj_clear_state(_obj, LV_STATE_DISABLED);
 				}
@@ -80,11 +79,11 @@ namespace lvgl {
 				}
 			}
 
-			inline bool getEnabled() {
+			inline bool GetEnabled() {
 				return lv_obj_has_state(_obj, LV_STATE_DISABLED);
 			}
 
-			void setChecked(bool checked) {
+			void SetChecked(bool checked) {
 				if (checked) {
 					lv_obj_add_state(_obj, LV_STATE_CHECKED);
 				}
@@ -93,11 +92,11 @@ namespace lvgl {
 				}
 			}
 
-			inline bool getChecked() {
+			inline bool GetChecked() {
 				return lv_obj_has_state(_obj, LV_STATE_CHECKED);
 			}
 
-			void setVisible(bool visible) {
+			void SetVisible(bool visible) {
 				if (visible) {
 					lv_obj_clear_flag(_obj, LV_OBJ_FLAG_HIDDEN);
 				}
@@ -106,16 +105,16 @@ namespace lvgl {
 				}
 			}
 
-			inline bool getVisible() {
+			inline bool GetVisible() {
 				return _obj->flags & LV_STATE_CHECKED ? false : true;
 			}
 			
-			inline Object *addFlag(lv_obj_flag_t f) {
+			inline Object *AddFlag(lv_obj_flag_t f) {
 				lv_obj_add_flag(_obj, f);
 				return this;
 			}
 
-			inline Object *clearFlag(lv_obj_flag_t f) {
+			inline Object *ClearFlag(lv_obj_flag_t f) {
 				lv_obj_clear_flag(_obj, f);
 				return this;
 			}
@@ -130,7 +129,7 @@ namespace lvgl {
 			 * @note            The position is interpreted on the content area of the parent
 			 * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
 			 */
-			inline Object *setPos(lv_coord_t x, lv_coord_t y) {
+			inline Object *SetPos(lv_coord_t x, lv_coord_t y) {
 				lv_obj_set_pos(_obj, x, y);
 			return this;
 			}
@@ -145,7 +144,7 @@ namespace lvgl {
 			 * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
 			 */
 
-			inline Object *setPosX(lv_coord_t x) {
+			inline Object *SetPosX(lv_coord_t x) {
 				lv_obj_set_x(_obj, x);
 			return this;
 			}
@@ -159,7 +158,7 @@ namespace lvgl {
 			 * @note            The position is interpreted on the content area of the parent
 			 * @note            The values can be set in pixel or in percentage of parent size with `lv_pct(v)`
 			 */
-			inline Object *setPosY(lv_coord_t y) {
+			inline Object *SetPosY(lv_coord_t y) {
 				lv_obj_set_y(_obj, y);
 			return this;
 			}
@@ -175,7 +174,7 @@ namespace lvgl {
 			 *                  LV_SIZE_PCT(x)     to set size in percentage of the parent's content area size (the size without paddings).
 			 *                                      x should be in [0..1000]% range
 			 */
-			inline Object *setSize(lv_coord_t w, lv_coord_t h) {
+			inline Object *SetSize(lv_coord_t w, lv_coord_t h) {
 				lv_obj_set_size(_obj, w, h);
 			return this;
 			}
@@ -186,7 +185,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @return          true: the size has been changed
 			 */
-			inline Object *setRefrSize() {
+			inline Object *SetRefrSize() {
 				lv_obj_refr_size(_obj);
 			return this;
 			}
@@ -202,7 +201,7 @@ namespace lvgl {
 			 *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
 			 *                                      x should be in [0..1000]% range
 			 */
-			inline Object *setWidth(lv_coord_t w) {
+			inline Object *SetWidth(lv_coord_t w) {
 				lv_obj_set_width(_obj, w);
 			return this;
 			}
@@ -218,7 +217,7 @@ namespace lvgl {
 			 *                  lv_pct(x)           to set size in percentage of the parent's content area size (the size without paddings).
 			 *                                      x should be in [0..1000]% range
 			 */
-			inline Object *setHeight(lv_coord_t h) {
+			inline Object *SetHeight(lv_coord_t h) {
 				lv_obj_set_height(_obj, h);
 			return this;
 			}
@@ -229,7 +228,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param w         the width without paddings in pixels
 			 */
-			inline Object *setContentWidth(lv_coord_t w) {
+			inline Object *SetContentWidth(lv_coord_t w) {
 				lv_obj_set_content_width(_obj, w);
 			return this;
 			}
@@ -240,7 +239,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param h         the height without paddings in pixels
 			 */
-			inline Object *setContentHeight(lv_coord_t h) {
+			inline Object *SetContentHeight(lv_coord_t h) {
 				lv_obj_set_content_height(_obj, h);
 			return this;
 			}
@@ -251,7 +250,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param layout    pointer to a layout descriptor to set
 			 */
-			inline Object *setLayout(uint32_t layout) {
+			inline Object *SetLayout(uint32_t layout) {
 				lv_obj_set_layout(_obj, layout);
 				return this;
 			}
@@ -261,7 +260,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object to test
 			 * @return true:    positioned by a layout; false: not positioned by a layout
 			 */
-			inline bool isLayoutPositioned() {
+			inline bool IsLayoutPositioned() {
 				return lv_obj_is_layout_positioned(_obj);
 			}
 
@@ -269,7 +268,7 @@ namespace lvgl {
 			 * Mark the object for layout update.
 			 * @param Object      pointer to an object whose children needs to be updated
 			 */
-			inline Object *markLayoutAsDirty() {
+			inline Object *MarkLayoutAsDirty() {
 				lv_obj_mark_layout_as_dirty(_obj);
 				return this;
 			}
@@ -278,7 +277,7 @@ namespace lvgl {
 			 * Update the layout of an object.
 			 * @param Object      pointer to an object whose children needs to be updated
 			 */
-			inline Object *updateLayout() {
+			inline Object *UpdateLayout() {
 				lv_obj_update_layout(_obj);
 				return this;
 			}
@@ -289,7 +288,7 @@ namespace lvgl {
 			 * @param user_data custom data that will be passed to `cb`
 			 * @return          the ID of the new layout
 			 */
-			inline uint32_t layoutRegister(lv_layout_update_cb_t cb, void * user_data) {
+			inline uint32_t LayoutRegister(lv_layout_update_cb_t cb, void * user_data) {
 				return lv_layout_register(cb, user_data);
 			}
 
@@ -298,7 +297,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object to align
 			 * @param align     type of alignment (see 'lv_align_t' enum) `LV_ALIGN_OUT_...` can't be used.
 			 */
-			inline Object *setAlign(lv_align_t align) {
+			inline Object *SetAlign(lv_align_t align) {
 				lv_obj_set_align(_obj,  align);
 				return this;
 			}
@@ -313,7 +312,7 @@ namespace lvgl {
 			 * @param x_ofs     x coordinate offset after alignment
 			 * @param y_ofs     y coordinate offset after alignment
 			 */
-			inline Object *setAlign(lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs) {
+			inline Object *SetAlign(lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs) {
 				lv_obj_align(_obj,  align,  x_ofs,  y_ofs);
 				return this;
 			}
@@ -327,7 +326,7 @@ namespace lvgl {
 			 * @param y_ofs     y coordinate offset after alignment
 			 * @note            if the position or size of `base` changes `Object` needs to be aligned manually again
 			 */
-			inline Object *setAlignTo(const lv_obj_t * _base, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs) {
+			inline Object *SetAlignTo(const lv_obj_t * _base, lv_align_t align, lv_coord_t x_ofs, lv_coord_t y_ofs) {
 				lv_obj_align_to(_obj, _base, align, x_ofs, y_ofs);
 				return this;
 			}
@@ -338,7 +337,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object to align
 			 * @note            if the parent size changes `Object` needs to be aligned manually again
 			 */
-			inline void setCenter() {
+			inline void SetCenter() {
 				lv_obj_center(_obj);
 			}
 
@@ -348,7 +347,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param coords    pointer to an area to store the coordinates
 			 */
-			inline Object *getCoords(lv_area_t * coords) {
+			inline Object *GetCoords(lv_area_t * coords) {
 				lv_obj_get_coords(_obj, coords);
 				return this;
 			}
@@ -363,7 +362,7 @@ namespace lvgl {
 			 * @note            Scrolling of the parent doesn't change the returned value.
 			 * @note            The returned value is always the distance from the parent even if `Object` is positioned by a layout.
 			 */
-			inline lv_coord_t getX() {
+			inline lv_coord_t GetX() {
 				return lv_obj_get_x(_obj);
 			}
 
@@ -377,7 +376,7 @@ namespace lvgl {
 			 * @note            Scrolling of the parent doesn't change the returned value.
 			 * @note            The returned value is always the distance from the parent even if `Object` is positioned by a layout.
 			 */
-			inline lv_coord_t getX2() {
+			inline lv_coord_t GetX2() {
 				return lv_obj_get_x2(_obj);
 			}
 
@@ -391,7 +390,7 @@ namespace lvgl {
 			 * @note            Scrolling of the parent doesn't change the returned value.
 			 * @note            The returned value is always the distance from the parent even if `Object` is positioned by a layout.
 			 */
-			inline lv_coord_t getY() {
+			inline lv_coord_t GetY() {
 				return lv_obj_get_y(_obj);
 			}
 
@@ -405,7 +404,7 @@ namespace lvgl {
 			 * @note            Scrolling of the parent doesn't change the returned value.
 			 * @note            The returned value is always the distance from the parent even if `Object` is positioned by a layout.
 			 */
-			inline lv_coord_t getY2() {
+			inline lv_coord_t GetY2() {
 				return lv_obj_get_y2(_obj);
 			}
 
@@ -414,7 +413,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @return          the set x coordinate
 			 */
-			inline lv_coord_t getXAligned() {
+			inline lv_coord_t GetXAligned() {
 				return lv_obj_get_x_aligned(_obj);
 			}
 
@@ -423,7 +422,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @return          the set y coordinate
 			 */
-			inline lv_coord_t getYAligned() {
+			inline lv_coord_t GetYAligned() {
 				return lv_obj_get_y_aligned(_obj);
 			}
 
@@ -434,7 +433,7 @@ namespace lvgl {
 			 *                  call `lv_obj_update_layout(Object)`.
 			 * @return          the width in pixels
 			 */
-			inline lv_coord_t getWidth() {
+			inline lv_coord_t GetWidth() {
 				return lv_obj_get_width(_obj);
 			}
 
@@ -445,7 +444,7 @@ namespace lvgl {
 			 *                  call `lv_obj_update_layout(Object)`.
 			 * @return          the height in pixels
 			 */
-			inline lv_coord_t getHeight() {
+			inline lv_coord_t GetHeight() {
 				return lv_obj_get_height(_obj);
 			}
 
@@ -456,7 +455,7 @@ namespace lvgl {
 			 *                  call `lv_obj_update_layout(Object)`.
 			 * @return          the width which still fits into its parent without causing overflow (making the parent scrollable)
 			 */
-			inline lv_coord_t getConstantWidth() {
+			inline lv_coord_t GetConstantWidth() {
 				return lv_obj_get_content_width(_obj);
 			}
 
@@ -467,7 +466,7 @@ namespace lvgl {
 			 *                  call `lv_obj_update_layout(Object)`.
 			 * @return          the height which still fits into the parent without causing overflow (making the parent scrollable)
 			 */
-			inline lv_coord_t getConstantHeight() {
+			inline lv_coord_t GetConstantHeight() {
 				return lv_obj_get_content_height(_obj);
 			}
 
@@ -478,7 +477,7 @@ namespace lvgl {
 			 *                  call `lv_obj_update_layout(Object)`.
 			 * @param area      the area which still fits into the parent without causing overflow (making the parent scrollable)
 			 */
-			inline Object *getContentCoords(lv_area_t * area) {
+			inline Object *GetContentCoords(lv_area_t * area) {
 				lv_obj_get_content_coords(_obj, area);
 				return this;
 			}
@@ -490,7 +489,7 @@ namespace lvgl {
 			 * @note            This size independent from the real size of the widget.
 			 *                  It just tells how large the internal ("virtual") content is.
 			 */
-			inline lv_coord_t getSelfWidth() {
+			inline lv_coord_t GetSelfWidth() {
 				return lv_obj_get_self_width(_obj);
 			}
 
@@ -501,7 +500,7 @@ namespace lvgl {
 			 * @note            This size independent from the real size of the widget.
 			 *                  It just tells how large the internal ("virtual") content is.
 			 */
-			inline lv_coord_t getSelfHeight() {
+			inline lv_coord_t GetSelfHeight() {
 				return lv_obj_get_self_height(_obj);
 			}
 
@@ -510,27 +509,27 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @return          false: nothing happened; true: refresh happened
 			 */
-			inline bool refreshSelfSize() {
+			inline bool RefreshSelfSize() {
 				return lv_obj_refresh_self_size(_obj);
 			}
 
-			inline Object *refrPos() {
+			inline Object *RefreshPos() {
 				lv_obj_refr_pos(_obj);
 				return this;
 			}
 
-			inline Object *moveTo(lv_coord_t x, lv_coord_t y) {
+			inline Object *MoveTo(lv_coord_t x, lv_coord_t y) {
 				lv_obj_move_to(_obj, x, y);
 				return this;
 			}
 
 
-			inline Object *mobeChildrenBy(lv_coord_t x_diff, lv_coord_t y_diff, bool ignore_floating) {
+			inline Object *MoveChildrenBy(lv_coord_t x_diff, lv_coord_t y_diff, bool ignore_floating) {
 				lv_obj_move_children_by(_obj, x_diff, y_diff, ignore_floating);
 				return this;
 			}
 
-			inline Object *clean() {
+			inline Object *Clean() {
 				lv_obj_clean(_obj);
 				return this;
 			}
@@ -542,7 +541,7 @@ namespace lvgl {
 			 * @param recursive     consider the transformation properties of the parents too
 			 * @param inv           do the inverse of the transformation (-angle and 1/zoom)
 			 */
-			inline Object *transformPoint(lv_point_t * p, bool recursive, bool inv) {
+			inline Object *TransformPoint(lv_point_t * p, bool recursive, bool inv) {
 				lv_obj_transform_point(_obj, p, recursive, inv);
 				return this;
 			}
@@ -554,7 +553,7 @@ namespace lvgl {
 			 * @param recursive     consider the transformation properties of the parents too
 			 * @param inv           do the inverse of the transformation (-angle and 1/zoom)
 			 */
-			inline Object *getTransformedArea(lv_area_t * area, bool recursive, bool inv) {
+			inline Object *GetTransformedArea(lv_area_t * area, bool recursive, bool inv) {
 				lv_obj_get_transformed_area(_obj, area, recursive, inv);
 				return this;
 			}
@@ -565,7 +564,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param           area the area to redraw
 			 */
-			inline Object *invalidateArea(const lv_area_t * area) {
+			inline Object *InvalidateArea(const lv_area_t * area) {
 				lv_obj_invalidate_area(_obj, area);
 				return this;
 			}
@@ -574,7 +573,7 @@ namespace lvgl {
 			 * Mark the object as invalid to redrawn its area
 			 * @param Object       pointer to an object
 			 */
-			inline Object *invalidate() {
+			inline Object *Invalidate() {
 				lv_obj_invalidate(_obj);
 				return this;
 			}
@@ -585,7 +584,7 @@ namespace lvgl {
 			 * @param area      the are to check. The visible part of the area will be written back here.
 			 * @return true     visible; false not visible (hidden, out of parent, on other screen, etc)
 			 */
-			inline bool areaIsVisible(lv_area_t * area) {
+			inline bool AreaIsVisible(lv_area_t * area) {
 				return lv_obj_area_is_visible(_obj, area);
 			}
 
@@ -594,7 +593,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @return      true: visible; false not visible (hidden, out of parent, on other screen, etc)
 			 */
-			inline bool isVisible() {
+			inline bool IsVisible() {
 				return lv_obj_is_visible(_obj);
 			}
 
@@ -603,7 +602,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param size      extended clickable area in all 4 directions [px]
 			 */
-			inline Object *setExtClickArea(lv_coord_t size) {
+			inline Object *SetExtClickArea(lv_coord_t size) {
 				lv_obj_set_ext_click_area(_obj, size);
 				return this;
 			}
@@ -614,7 +613,7 @@ namespace lvgl {
 			 * @param Object       pointer to an object
 			 * @param area      store the result area here
 			 */
-			inline Object *getClickArea(lv_area_t * area) {
+			inline Object *GetClickArea(lv_area_t * area) {
 				lv_obj_get_click_area(_obj, area);
 				return this;
 			}
@@ -625,7 +624,7 @@ namespace lvgl {
 			 * @param point     screen-space point (absolute coordinate)
 			 * @return          true: if the object is considered under the point
 			 */
-			inline bool hitTest(const lv_point_t * point) {
+			inline bool HitTest(const lv_point_t * point) {
 				return lv_obj_hit_test(_obj, point);
 			}
 
@@ -637,7 +636,7 @@ namespace lvgl {
 			 * @param ref_width     the reference width used when min/max width is in percentage
 			 * @return              the clamped width
 			 */
-			inline lv_coord_t clampWidth(lv_coord_t width, lv_coord_t min_width, lv_coord_t max_width, lv_coord_t ref_width) {
+			inline lv_coord_t ClampWidth(lv_coord_t width, lv_coord_t min_width, lv_coord_t max_width, lv_coord_t ref_width) {
 				return lv_clamp_width(width, min_width, max_width, ref_width);
 			}
 
@@ -649,488 +648,488 @@ namespace lvgl {
 			 * @param ref_height     the reference height used when min/max height is in percentage
 			 * @return              the clamped height
 			 */
-			inline lv_coord_t champHeight(lv_coord_t height, lv_coord_t min_height, lv_coord_t max_height, lv_coord_t ref_height) {
+			inline lv_coord_t ChampHeight(lv_coord_t height, lv_coord_t min_height, lv_coord_t max_height, lv_coord_t ref_height) {
 				return lv_clamp_height(height, min_height, max_height, ref_height);
 			}
 
 
 
 
-			inline Object *setStyleWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *sSetStyleWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleMinWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleMinWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_min_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleMaxWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleMaxWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_max_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleHeight(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleHeight(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_height(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleMinHeight(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleMinHeight(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_min_height(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleMaxHeight(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleMaxHeight(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_max_height(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleX(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleX(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_x(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleY(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleY(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_y(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleAlign(lv_align_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleAlign(lv_align_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_align(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_transform_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformHeight(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformHeight(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_transform_height(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformX(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformX(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_translate_x(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformY(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformY(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_translate_y(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformZoom(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformZoom(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_transform_zoom(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTranbsformAngle(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTranbsformAngle(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_transform_angle(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformPivotX(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformPivotX(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_transform_pivot_x(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformPivotY(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformPivotY(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_transform_pivot_y(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformPadTop(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformPadTop(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_top(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformPadBottom(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformPadBottom(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_bottom(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformPadLeft(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformPadLeft(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_left(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransformPadRight(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransformPadRight(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_right(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStylePadRow(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStylePadRow(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_row(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStylePadCollumn(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStylePadCollumn(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_column(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgGradColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgGradColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_grad_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgGradDir(lv_grad_dir_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgGradDir(lv_grad_dir_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_grad_dir(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgMainStop(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgMainStop(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_main_stop(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgGradStop(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgGradStop(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_grad_stop(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgGrad(const lv_grad_dsc_t * value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgGrad(const lv_grad_dsc_t * value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_grad(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgDitherMode(lv_dither_mode_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgDitherMode(lv_dither_mode_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_dither_mode(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgImgSrc(const void * value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgImgSrc(const void * value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_img_src(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgImgOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgImgOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_img_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgImgRecolor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgImgRecolor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_img_recolor(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgImgRecolorOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgImgRecolorOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_img_recolor_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBgImgTiled(bool value, lv_style_selector_t selector) {
+			inline Object *SetStyleBgImgTiled(bool value, lv_style_selector_t selector) {
 				lv_obj_set_style_bg_img_tiled(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBorderColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBorderColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_border_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBorderOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBorderOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_border_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBorderWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBorderWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_border_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBorderSide(lv_border_side_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBorderSide(lv_border_side_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_border_side(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBorderPost(bool value, lv_style_selector_t selector) {
+			inline Object *SetStyleBorderPost(bool value, lv_style_selector_t selector) {
 				lv_obj_set_style_border_post(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleOutlineWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleOutlineWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_outline_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleOutlineColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleOutlineColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_outline_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleOutlineOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleOutlineOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_outline_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleOutlinePad(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleOutlinePad(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_outline_pad(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleShadowWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleShadowWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_shadow_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleShadowOfsX(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleShadowOfsX(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_shadow_ofs_x(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleShadowOfsY(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleShadowOfsY(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_shadow_ofs_y(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleShadowSpread(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleShadowSpread(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_shadow_spread(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleShadowColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleShadowColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_shadow_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleShadowOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleShadowOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_shadow_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleImgOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleImgOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_img_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleImgRecolor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleImgRecolor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_img_recolor(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleImgRecolorOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleImgRecolorOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_img_recolor_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLineWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleLineWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_line_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLineDashWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleLineDashWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_line_dash_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLineDashGap(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleLineDashGap(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_line_dash_gap(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLineRounded(bool value, lv_style_selector_t selector) {
+			inline Object *SetStyleLineRounded(bool value, lv_style_selector_t selector) {
 				lv_obj_set_style_line_rounded(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLineColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleLineColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_line_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLineOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleLineOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_line_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleArcWidth(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleArcWidth(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_arc_width(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleArcRounded(bool value, lv_style_selector_t selector) {
+			inline Object *SetStyleArcRounded(bool value, lv_style_selector_t selector) {
 				lv_obj_set_style_arc_rounded(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleArcColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleArcColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_arc_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleArcOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleArcOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_arc_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleArcImgSrc(const void * value, lv_style_selector_t selector) {
+			inline Object *SetStyleArcImgSrc(const void * value, lv_style_selector_t selector) {
 				lv_obj_set_style_arc_img_src(_obj,value, selector);
 				return this;
 			}
-			inline Object *setStyleTextColor(lv_color_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextColor(lv_color_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_color(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTextOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTextFont(const lv_font_t * value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextFont(const lv_font_t * value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_font(_obj,value, selector);
 				return this;
 			}
-			inline Object *setStyleTextLetterSpace(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextLetterSpace(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_letter_space(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTextLineSpace(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextLineSpace(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_line_space(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTextDecor(lv_text_decor_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextDecor(lv_text_decor_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_decor(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTextAlign(lv_text_align_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleTextAlign(lv_text_align_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_text_align(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStylePadAll(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStylePadAll(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_all(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleRadius(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleRadius(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_radius(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleClipCorner(bool value, lv_style_selector_t selector) {
+			inline Object *SetStyleClipCorner(bool value, lv_style_selector_t selector) {
 				lv_obj_set_style_clip_corner(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleOpaLayered(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleOpaLayered(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_opa_layered(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleColorFilterDsc(const lv_color_filter_dsc_t * value, lv_style_selector_t selector) {
+			inline Object *SetStyleColorFilterDsc(const lv_color_filter_dsc_t * value, lv_style_selector_t selector) {
 				lv_obj_set_style_color_filter_dsc(_obj,value, selector);
 				return this;
 			}
-			inline Object *setStyleColorFilterOpa(lv_opa_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleColorFilterOpa(lv_opa_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_color_filter_opa(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleAnim(const lv_anim_t * value, lv_style_selector_t selector) {
+			inline Object *SetStyleAnim(const lv_anim_t * value, lv_style_selector_t selector) {
 				lv_obj_set_style_anim(_obj,value, selector);
 				return this;
 			}
-			inline Object *setStyleAnimTime(uint32_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleAnimTime(uint32_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_anim_time(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleAnimSpeed(uint32_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleAnimSpeed(uint32_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_anim_speed(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleTransition(const lv_style_transition_dsc_t * value, lv_style_selector_t selector) {
+			inline Object *SetStyleTransition(const lv_style_transition_dsc_t * value, lv_style_selector_t selector) {
 				lv_obj_set_style_transition(_obj,value, selector);
 				return this;
 			}
-			inline Object *setStyleBlendMode(lv_blend_mode_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBlendMode(lv_blend_mode_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_blend_mode(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleLayout(uint16_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleLayout(uint16_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_layout(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleBaseDir(lv_base_dir_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleBaseDir(lv_base_dir_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_base_dir(_obj, value, selector);
 				return this;
 			}
-			inline Object *addEventCbValueChanged(lv_event_cb_t event_cb, void * user_data = NULL) {
+			inline Object *AddEventCbValueChanged(lv_event_cb_t event_cb, void * user_data = NULL) {
 				lv_obj_add_event_cb(_obj, event_cb, LV_EVENT_VALUE_CHANGED, user_data);
 				return this;
 			}
-			inline Object *addEventCbClicked(lv_event_cb_t event_cb, void * user_data = NULL) {
+			inline Object *AddEventCbClicked(lv_event_cb_t event_cb, void * user_data = NULL) {
 				lv_obj_add_event_cb(_obj, event_cb, LV_EVENT_CLICKED, user_data);
 				return this;
 			}
 			
-			inline Object *addStyle(lv_style_t * style, lv_style_selector_t selector) {
+			inline Object *AddStyle(lv_style_t * style, lv_style_selector_t selector) {
 				lv_obj_add_style(_obj, style, selector);
 				return this;
 			}
 			
-			inline Object *addStyle(lvgl::Style * style, lv_style_selector_t selector) {
-				lv_obj_add_style(_obj, style->get(), selector);
+			inline Object *AddStyle(lvgl::Style * style, lv_style_selector_t selector) {
+				lv_obj_add_style(_obj, style->Get(), selector);
 				return this;
 			}
 			
-			/*inline Object *addStyle(lvgl::Style style, lv_style_selector_t selector) {
-				lv_obj_add_style(_obj, style.get(), selector);
+			/*inline Object *AddStyle(lvgl::Style style, lv_style_selector_t selector) {
+				lv_obj_add_style(_obj, style.Get(), selector);
 				return this;
 			}*/
 			
-			inline Object *removeStyle(lv_style_t * style, lv_style_selector_t selector) {
+			inline Object *RemoveStyle(lv_style_t * style, lv_style_selector_t selector) {
 				lv_obj_remove_style(_obj, style, selector);
 				return this;
 			}
 			
-			inline Object *removeStyleAll() {
+			inline Object *RemoveStyleAll() {
 				lv_obj_remove_style(_obj, NULL, (lv_style_selector_t)LV_PART_ANY | (lv_style_selector_t)LV_STATE_ANY);
 				return this;
 			}
 			
-			inline Object *reportStyleChanged(lv_style_t * style) {
+			inline Object *ReportStyleChanged(lv_style_t * style) {
 				lv_obj_report_style_change(style);
 				return this;
 			}
 			
-			inline Object *refreshStyle(lv_part_t part, lv_style_prop_t prop) {
+			inline Object *RefreshStyle(lv_part_t part, lv_style_prop_t prop) {
 				lv_obj_refresh_style(_obj, part, prop);
 				return this;
 			}
 			
-			inline Object *enableStyleRefresh(bool en) {
+			inline Object *EnableStyleRefresh(bool en) {
 				lv_obj_enable_style_refresh(en);
 				return this;
 			}
 			
-			inline lv_style_value_t getStyleProp(lv_part_t part, lv_style_prop_t prop) {
+			inline lv_style_value_t GetStyleProp(lv_part_t part, lv_style_prop_t prop) {
 				return lv_obj_get_style_prop(_obj, part, prop);
 			}
 			
-			inline Object *setLocalStyleProp(lv_style_prop_t prop, lv_style_value_t value, lv_style_selector_t selector) {
+			inline Object *SetLocalStyleProp(lv_style_prop_t prop, lv_style_value_t value, lv_style_selector_t selector) {
 				lv_obj_set_local_style_prop(_obj, prop, value, selector);
 				return this;
 			}
 			
-			inline Object *setLocalStylePropMeta(lv_style_prop_t prop, uint16_t meta, lv_style_selector_t selector) {
+			inline Object *SetLocalStylePropMeta(lv_style_prop_t prop, uint16_t meta, lv_style_selector_t selector) {
 				lv_obj_set_local_style_prop_meta(_obj, prop, meta, selector);
 				return this;
 			}
 			
-			inline lv_style_res_t getLocalStyleProp(lv_style_prop_t prop, lv_style_value_t * value, lv_style_selector_t selector) {
+			inline lv_style_res_t GetLocalStyleProp(lv_style_prop_t prop, lv_style_value_t * value, lv_style_selector_t selector) {
 				return lv_obj_get_local_style_prop(_obj, prop, value, selector);
 			}
 			
-			inline bool removeLocalStyleProp(lv_style_prop_t prop, lv_style_selector_t selector) {
+			inline bool RemoveLocalStyleProp(lv_style_prop_t prop, lv_style_selector_t selector) {
 				return lv_obj_remove_local_style_prop(_obj, prop, selector);
 			}
 			
-			inline lv_style_value_t styleApplyColorFilter(uint32_t part, lv_style_value_t v) {
+			inline lv_style_value_t StyleApplyColorFilter(uint32_t part, lv_style_value_t v) {
 				return _lv_obj_style_apply_color_filter(_obj, part, v);
 			}
 			
-			inline Object *styleCreateTransition(lv_part_t part, lv_state_t prev_state, lv_state_t new_state, const _lv_obj_style_transition_dsc_t * tr) {
+			inline Object *StyleCreateTransition(lv_part_t part, lv_state_t prev_state, lv_state_t new_state, const _lv_obj_style_transition_dsc_t * tr) {
 				_lv_obj_style_create_transition(_obj, part, prev_state, new_state, tr);
 				return this;
 			}
 			
-			inline _lv_style_state_cmp_t styleStateCompare(lv_state_t state1, lv_state_t state2) {
+			inline _lv_style_state_cmp_t StyleStateCompare(lv_state_t state1, lv_state_t state2) {
 				return _lv_obj_style_state_compare(_obj, state1, state2);
 			}
 			
-			inline Object *fadeIn(uint32_t time, uint32_t delay) {
+			inline Object *FadeIn(uint32_t time, uint32_t delay) {
 				lv_obj_fade_in(_obj, time, delay);
 				return this;
 			}
 			
-			inline Object *fadeOut(uint32_t time, uint32_t delay) {
+			inline Object *FadeOut(uint32_t time, uint32_t delay) {
 				lv_obj_fade_out(_obj, time, delay);
 				return this;
 			}
 			
-			inline lv_state_t styleGetSelectorState(lv_style_selector_t selector) {
+			inline lv_state_t StyleGetSelectorState(lv_style_selector_t selector) {
 				return lv_obj_style_get_selector_state(selector);
 			}
 			
-			inline lv_part_t styleGetSelectorPart(lv_style_selector_t selector) {
+			inline lv_part_t StyleGetSelectorPart(lv_style_selector_t selector) {
 				return lv_obj_style_get_selector_part(selector);
 			}
 			
-			inline Object *setStylePadHor(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStylePadHor(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_hor(_obj, value, selector);
 				return this;
 			}
 			
-			inline Object *setStylePadVer(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStylePadVer(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_ver(_obj, value, selector);
 				return this;
 			}
 			
-			inline Object *setStylePadGap(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStylePadGap(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_pad_gap(_obj, value, selector);
 				return this;
 			}
 			
-			inline Object *setStyleSize(lv_coord_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleSize(lv_coord_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_size(_obj, value, selector);
 				return this;
 			}
 			
-			inline lv_text_align_t calculateTextAlign(lv_part_t part, const char * txt) {
+			inline lv_text_align_t CalculateTextAlign(lv_part_t part, const char * txt) {
 				return lv_obj_calculate_style_text_align(_obj, part, txt);
 			}
 			
-			inline lv_text_align_t getStyleTransformZoomSafe(uint32_t part) {
+			inline lv_text_align_t GetStyleTransformZoomSafe(uint32_t part) {
 				return lv_obj_get_style_transform_zoom_safe(_obj, part);
 			}
 			
-			inline lv_opa_t getStyleOpaRecursive(lv_part_t part) {
+			inline lv_opa_t GetStyleOpaRecursive(lv_part_t part) {
 				return lv_obj_get_style_opa_recursive(_obj, part);
 			}
 			
@@ -1142,7 +1141,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param mode      LV_SCROLL_MODE_ON/OFF/AUTO/ACTIVE
 		 */
-			inline Object *setScrollbarMode(lv_scrollbar_mode_t mode) {
+			inline Object *SetScrollbarMode(lv_scrollbar_mode_t mode) {
 				lv_obj_set_scrollbar_mode(_obj, mode);
 				return this;
 			}
@@ -1152,7 +1151,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param dir       the allow scroll directions. An element or OR-ed values of `lv_dir_t`
 		 */
-			inline Object *setScrollDirection(lv_dir_t dir) {
+			inline Object *SetScrollDirection(lv_dir_t dir) {
 				lv_obj_set_scroll_dir(_obj, dir);
 				return this;
 			}
@@ -1162,7 +1161,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param align     the snap align to set from `lv_scroll_snap_t`
 		 */
-			inline Object *setScrollSnapX(lv_scroll_snap_t align) {
+			inline Object *SetScrollSnapX(lv_scroll_snap_t align) {
 				lv_obj_set_scroll_snap_x(_obj, align);
 				return this;
 			}
@@ -1172,7 +1171,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param align     the snap align to set from `lv_scroll_snap_t`
 		 */
-			inline Object *setScrollSnapY(lv_scroll_snap_t align) {
+			inline Object *SetScrollSnapY(lv_scroll_snap_t align) {
 				lv_obj_set_scroll_snap_y(_obj, align);
 				return this;
 			}
@@ -1186,7 +1185,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @return          the current scroll mode from `lv_scrollbar_mode_t`
 		 */
-			lv_scrollbar_mode_t getScrollbarMode() {
+			lv_scrollbar_mode_t GetScrollbarMode() {
 				return lv_obj_get_scrollbar_mode(_obj);
 			}
 
@@ -1195,7 +1194,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param dir       the allow scroll directions. An element or OR-ed values of `lv_dir_t`
 		 */
-			lv_dir_t getScrollDirection() {
+			lv_dir_t GetScrollDirection() {
 				return lv_obj_get_scroll_dir(_obj);
 			}
 
@@ -1204,7 +1203,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @return          the current snap align from `lv_scroll_snap_t`
 		 */
-			lv_scroll_snap_t getScrollSnapX() {
+			lv_scroll_snap_t GetScrollSnapX() {
 				return lv_obj_get_scroll_snap_x(_obj);
 			}
 
@@ -1213,7 +1212,7 @@ namespace lvgl {
 		 * @param  obj      pointer to an object
 		 * @return          the current snap align from `lv_scroll_snap_t`
 		 */
-			lv_scroll_snap_t getScrollSnapY() {
+			lv_scroll_snap_t GetScrollSnapY() {
 				return lv_obj_get_scroll_snap_y(_obj);
 			}
 
@@ -1225,7 +1224,7 @@ namespace lvgl {
 		 *                  If scrolled return > 0
 		 *                  If scrolled in (elastic scroll) return < 0
 		 */
-			lv_coord_t getScrollX() {
+			lv_coord_t GetScrollX() {
 				return lv_obj_get_scroll_x(_obj);
 			}
 
@@ -1237,7 +1236,7 @@ namespace lvgl {
 		 *                  If scrolled return > 0
 		 *                  If scrolled inside return < 0
 		 */
-			lv_coord_t getScrollY() {
+			lv_coord_t GetScrollY() {
 				return lv_obj_get_scroll_y(_obj);
 			}
 
@@ -1248,7 +1247,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @return          the scrollable area above the object in pixels
 		 */
-			lv_coord_t getScrollTop() {
+			lv_coord_t GetScrollTop() {
 				return lv_obj_get_scroll_top(_obj);
 			}
 
@@ -1259,7 +1258,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @return          the scrollable area below the object in pixels
 		 */
-			lv_coord_t getScrollBottom() {
+			lv_coord_t GetScrollBottom() {
 				return lv_obj_get_scroll_bottom(_obj);
 			}
 
@@ -1270,7 +1269,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @return          the scrollable area on the left the object in pixels
 		 */
-			lv_coord_t getScrollLeft() {
+			lv_coord_t GetScrollLeft() {
 				return lv_obj_get_scroll_left(_obj);
 			}
 
@@ -1281,7 +1280,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @return          the scrollable area on the right the object in pixels
 		 */
-			lv_coord_t getScrollRight() {
+			lv_coord_t GetScrollRight() {
 				return lv_obj_get_scroll_right(_obj);
 			}
 
@@ -1291,7 +1290,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param end       pointer to store the result
 		 */
-			inline Object *getScrollEnd(lv_point_t * end) {
+			inline Object *GetScrollEnd(lv_point_t * end) {
 				lv_obj_get_scroll_end(_obj, end);
 				return this;
 			}
@@ -1309,7 +1308,7 @@ namespace lvgl {
 		 * @note            > 0 value means scroll right/bottom (show the more content on the right/bottom)
 		 * @note            e.g. dy = -20 means scroll down 20 px
 		 */
-			inline Object *scrollBy(lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en) {
+			inline Object *ScrollBy(lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en) {
 				lv_obj_scroll_by(_obj, x, y, anim_en);
 				return this;
 			}
@@ -1323,7 +1322,7 @@ namespace lvgl {
 		 * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
 		 * @note            e.g. dy = -20 means scroll down 20 px
 		 */
-			inline Object *scrollByBounded(lv_coord_t dx, lv_coord_t dy, lv_anim_enable_t anim_en) {
+			inline Object *ScrollByBounded(lv_coord_t dx, lv_coord_t dy, lv_anim_enable_t anim_en) {
 				lv_obj_scroll_by_bounded(_obj, dx, dy, anim_en);
 				return this;
 			}
@@ -1336,7 +1335,7 @@ namespace lvgl {
 		 * @param y         pixels to scroll vertically
 		 * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
 		 */
-			inline Object *scrollTo(lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en) {
+			inline Object *ScrollTo(lv_coord_t x, lv_coord_t y, lv_anim_enable_t anim_en) {
 				lv_obj_scroll_to(_obj, x, y, anim_en);
 				return this;
 			}
@@ -1348,7 +1347,7 @@ namespace lvgl {
 		 * @param x         pixels to scroll horizontally
 		 * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
 		 */
-			inline Object *scrollToX(lv_coord_t x, lv_anim_enable_t anim_en) {
+			inline Object *ScrollToX(lv_coord_t x, lv_anim_enable_t anim_en) {
 				lv_obj_scroll_to_x(_obj, x, anim_en);
 				return this;
 			}
@@ -1360,7 +1359,7 @@ namespace lvgl {
 		 * @param y         pixels to scroll vertically
 		 * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
 		 */
-			inline Object *scrollToY(lv_coord_t y, lv_anim_enable_t anim_en) {
+			inline Object *ScrollToY(lv_coord_t y, lv_anim_enable_t anim_en) {
 				lv_obj_scroll_to_y(_obj, y, anim_en);
 				return this;
 			}
@@ -1370,7 +1369,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object to scroll into view
 		 * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
 		 */
-			inline Object *scrollToView(lv_anim_enable_t anim_en) {
+			inline Object *ScrollToView(lv_anim_enable_t anim_en) {
 				lv_obj_scroll_to_view(_obj, anim_en);
 				return this;
 			}
@@ -1382,7 +1381,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object to scroll into view
 		 * @param anim_en   LV_ANIM_ON: scroll with animation; LV_ANIM_OFF: scroll immediately
 		 */
-			inline Object *scrollToViewRecursive(lv_anim_enable_t anim_en) {
+			inline Object *ScrollToViewRecursive(lv_anim_enable_t anim_en) {
 				lv_obj_scroll_to_view_recursive(_obj, anim_en);
 				return this;
 			}
@@ -1396,7 +1395,7 @@ namespace lvgl {
 		 * @return          `LV_RES_INV`: to object was deleted in `LV_EVENT_SCROLL`;
 		 *                  `LV_RES_OK`: if the object is still valid
 		 */
-			lv_res_t scrollByRaw(lv_coord_t x, lv_coord_t y) {
+			lv_res_t ScrollByRaw(lv_coord_t x, lv_coord_t y) {
 				_lv_obj_scroll_by_raw(_obj, x, y);
 			}
 
@@ -1405,7 +1404,7 @@ namespace lvgl {
 		 * @param obj   pointer to an object
 		 * @return      true: `obj` is being scrolled
 		 */
-			bool isScrolling() {
+			bool IsScrolling() {
 				return lv_obj_is_scrolling(_obj);
 			}
 
@@ -1414,7 +1413,7 @@ namespace lvgl {
 		 * @param obj       an object whose children needs to checked and snapped
 		 * @param anim_en   LV_ANIM_ON/OFF
 		 */
-			inline Object *updateSnap(lv_anim_enable_t anim_en) {
+			inline Object *UpdateSnap(lv_anim_enable_t anim_en) {
 				lv_obj_update_snap(_obj, anim_en);
 				return this;
 			}
@@ -1425,7 +1424,7 @@ namespace lvgl {
 		 * @param hor   pointer to store the area of the horizontal scrollbar
 		 * @param ver   pointer to store the area of the vertical  scrollbar
 		 */
-			inline Object *getScrollbarArea(lv_area_t * hor, lv_area_t * ver) {
+			inline Object *GetScrollbarArea(lv_area_t * hor, lv_area_t * ver) {
 				lv_obj_get_scrollbar_area(_obj, hor, ver);
 				return this;
 			}
@@ -1434,7 +1433,7 @@ namespace lvgl {
 		 * Invalidate the area of the scrollbars
 		 * @param obj       pointer to an object
 		 */
-			inline Object *scrollbarInvalidate() {
+			inline Object *ScrollbarInvalidate() {
 				lv_obj_scrollbar_invalidate(_obj);
 				return this;
 			}
@@ -1444,7 +1443,7 @@ namespace lvgl {
 		 * @param obj       pointer to an object
 		 * @param anim_en   LV_ANIM_ON/OFF
 		 */
-			inline Object *readjustScroll(lv_anim_enable_t anim_en) {
+			inline Object *ReadjustScroll(lv_anim_enable_t anim_en) {
 				lv_obj_readjust_scroll(_obj, anim_en);
 				return this;
 			}
@@ -1459,7 +1458,7 @@ namespace lvgl {
 		 * @param flex pointer to a flex layout descriptor
 		 * @param flow an element of `lv_flex_flow_t`.
 		 */
-			inline Object *setFlexFlow(lv_flex_flow_t flow) {
+			inline Object *SetFlexFlow(lv_flex_flow_t flow) {
 				lv_obj_set_flex_flow(_obj, flow);
 				return this;
 			}
@@ -1471,7 +1470,7 @@ namespace lvgl {
 		 * @param cross_place where to place the item in their track on the cross axis. `LV_FLEX_ALIGN_START/END/CENTER`
 		 * @param track_place where to place the tracks in the cross direction. Any value of `lv_flex_align_t`.
 		 */
-			inline Object *setFlexAlign(lv_flex_align_t main_place, lv_flex_align_t cross_place,
+			inline Object *SetFlexAlign(lv_flex_align_t main_place, lv_flex_align_t cross_place,
 						               lv_flex_align_t track_cross_place) {
 				lv_obj_set_flex_align(_obj, main_place, cross_place, track_cross_place);
 				return this;
@@ -1482,28 +1481,28 @@ namespace lvgl {
 		 * @param obj pointer to an object. The parent must have flex layout else nothing will happen.
 		 * @param grow a value to set how much free space to take proportionally to other growing items.
 		 */
-			inline Object *setFlexGrow(uint8_t grow) {
+			inline Object *SetFlexGrow(uint8_t grow) {
 				lv_obj_set_flex_grow(_obj, grow);
 				return this;
 			}
 
-			inline Object *setStyleFlexFlow(lv_flex_flow_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleFlexFlow(lv_flex_flow_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_flex_flow(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleFlexMainPlace(lv_flex_align_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleFlexMainPlace(lv_flex_align_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_flex_main_place(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleFlexCrossPlace(lv_flex_align_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleFlexCrossPlace(lv_flex_align_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_flex_cross_place(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleFlexTrackPlace(lv_flex_align_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleFlexTrackPlace(lv_flex_align_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_flex_track_place(_obj, value, selector);
 				return this;
 			}
-			inline Object *setStyleFlexGrow(uint8_t value, lv_style_selector_t selector) {
+			inline Object *SetStyleFlexGrow(uint8_t value, lv_style_selector_t selector) {
 				lv_obj_set_style_flex_grow(_obj, value, selector);
 				return this;
 			}
@@ -1520,7 +1519,7 @@ namespace lvgl {
 		 * @param param         arbitrary data depending on the widget type and the event. (Usually `NULL`)
 		 * @return LV_RES_OK: `obj` was not deleted in the event; LV_RES_INV: `obj` was deleted in the event_code
 		 */
-			lv_res_t eventSend(lv_event_code_t event_code, void * param) {
+			lv_res_t EventSend(lv_event_code_t event_code, void * param) {
 				return lv_event_send(_obj, event_code, param);
 			}
 
@@ -1530,7 +1529,7 @@ namespace lvgl {
 		 * @param e         pointer to the event descriptor
 		 * @return          LV_RES_OK: the target object was not deleted in the event; LV_RES_INV: it was deleted in the event_code
 		 */
-			static lv_res_t eventBase(const lv_obj_class_t *class_p, lv_event_t *e) {
+			static lv_res_t EventBase(const lv_obj_class_t *class_p, lv_event_t *e) {
 				lv_obj_event_base(class_p, e);
 			}
 
@@ -1539,7 +1538,7 @@ namespace lvgl {
 		 * @param e     pointer to the event descriptor
 		 * @return      the target of the event_code
 		 */
-			static struct _lv_obj_t *eventGetTarget(lv_event_t *e) {
+			static struct _lv_obj_t *EventGetTarget(lv_event_t *e) {
 				return lv_event_get_target(e);
 			}
 
@@ -1549,7 +1548,7 @@ namespace lvgl {
 		 * @param e     pointer to the event descriptor
 		 * @return      pointer to the current target of the event_code
 		 */
-			static struct _lv_obj_t *eventGetCurrentTarget(lv_event_t *e) {
+			static struct _lv_obj_t *EventGetCurrentTarget(lv_event_t *e) {
 				return lv_event_get_current_target(e);
 			}
 
@@ -1558,7 +1557,7 @@ namespace lvgl {
 		 * @param e     pointer to the event descriptor
 		 * @return      the event code. (E.g. `LV_EVENT_CLICKED`, `LV_EVENT_FOCUSED`, etc)
 		 */
-			static lv_event_code_t eventGetCode(lv_event_t *e) {
+			static lv_event_code_t EventGetCode(lv_event_t *e) {
 				return lv_event_get_code(e);
 			}
 
@@ -1567,7 +1566,7 @@ namespace lvgl {
 		 * @param e     pointer to the event descriptor
 		 * @return      pointer to the parameter
 		 */
-			static void *eventGetParam(lv_event_t *e) {
+			static void *EventGetParam(lv_event_t *e) {
 				return lv_event_get_param(e);
 			}
 
@@ -1576,7 +1575,7 @@ namespace lvgl {
 		 * @param e     pointer to the event descriptor
 		 * @return      pointer to the user_data
 		 */
-			static void *eventGetUserData(lv_event_t *e) {
+			static void *EventGetUserData(lv_event_t *e) {
 				return lv_event_get_user_data(e);
 			}
 
@@ -1585,7 +1584,7 @@ namespace lvgl {
 		 * This is only valid when called in the middle of an event processing chain.
 		 * @param e     pointer to the event descriptor
 		 */
-			static void eventStopBubbling(lv_event_t *e) {
+			static void EventStopBubbling(lv_event_t *e) {
 				lv_event_stop_bubbling(e);
 			}
 
@@ -1594,7 +1593,7 @@ namespace lvgl {
 		 * This is only valid when called in the middle of an event processing chain.
 		 * @param e     pointer to the event descriptor
 		 */
-			static void eventStopProcessing(lv_event_t *e) {
+			static void EventStopProcessing(lv_event_t *e) {
 				lv_event_stop_processing(e);
 			}
 
@@ -1609,7 +1608,7 @@ namespace lvgl {
 		 * ...
 		 * lv_event_send(obj, LV_EVENT_MINE, &some_data);
 		 */
-			static uint32_t eventRegisterId() {
+			static uint32_t EventRegisterId() {
 				return lv_event_register_id();
 			}
 
@@ -1618,7 +1617,7 @@ namespace lvgl {
 		 * Mark this object's `event_temp_data` deleted to know that its `lv_event_send` should return `LV_RES_INV`
 		 * @param obj pointer to an object to mark as deleted
 		 */
-			void eventMarkDeleted() {
+			void EventMarkDeleted() {
 				_lv_event_mark_deleted(_obj);
 			}
 
@@ -1632,7 +1631,7 @@ namespace lvgl {
 		 * @param           user_data custom data data will be available in `event_cb`
 		 * @return          a pointer the event descriptor. Can be used in ::lv_obj_remove_event_dsc
 		 */
-			struct _lv_event_dsc_t * addEventCb(lv_event_cb_t event_cb, lv_event_code_t filter,
+			struct _lv_event_dsc_t * AddEventCb(lv_event_cb_t event_cb, lv_event_code_t filter,
 						                                 void * user_data) {
 				return lv_obj_add_event_cb(_obj, event_cb, filter, user_data);
 			}
@@ -1643,7 +1642,7 @@ namespace lvgl {
 		 * @param event_cb  the event function to remove, or `NULL` to remove the firstly added event callback
 		 * @return          true if any event handlers were removed
 		 */
-			bool removeEventCb(lv_event_cb_t event_cb) {
+			bool RemoveEventCb(lv_event_cb_t event_cb) {
 				return lv_obj_remove_event_cb(_obj, event_cb);
 			}
 
@@ -1654,7 +1653,7 @@ namespace lvgl {
 		 * @param event_user_data   the user_data specified in ::lv_obj_add_event_cb
 		 * @return                  true if any event handlers were removed
 		 */
-			bool removeEventCbWithUserData(lv_event_cb_t event_cb, const void * event_user_data) {
+			bool RemoveEventCbWithUserData(lv_event_cb_t event_cb, const void * event_user_data) {
 				return lv_obj_remove_event_cb_with_user_data(_obj, event_cb, event_user_data);
 			}
 
@@ -1665,7 +1664,7 @@ namespace lvgl {
 		 * @param event_dsc pointer to an event descriptor to remove (returned by ::lv_obj_add_event_cb)
 		 * @return          true if any event handlers were removed
 		 */
-			bool removeEventDsc(struct _lv_event_dsc_t * event_dsc) {
+			bool RemoveEventDsc(struct _lv_event_dsc_t * event_dsc) {
 				return lv_obj_remove_event_dsc(_obj, event_dsc);
 			}
 
@@ -1675,7 +1674,7 @@ namespace lvgl {
 		 * @param event_cb          the event function
 		 * @return                  the user_data
 		 */
-			void *getEventUserData(lv_event_cb_t event_cb) {
+			void *GetEventUserData(lv_event_cb_t event_cb) {
 				return lv_obj_get_event_user_data(_obj, event_cb);
 			}
 
@@ -1684,7 +1683,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      the indev that triggered the event or NULL if called on a not indev related event
 		 */
-			static lv_indev_t * eventGetIndev(lv_event_t *e) {
+			static lv_indev_t * EventGetIndev(lv_event_t *e) {
 				return lv_event_get_indev(e);
 			}
 
@@ -1693,7 +1692,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      the part draw descriptor to hook the drawing or NULL if called on an unrelated event
 		 */
-			static lv_obj_draw_part_dsc_t *eventGetDrawPartRescriptor(lv_event_t *e) {
+			static lv_obj_draw_part_dsc_t *EventGetDrawPartRescriptor(lv_event_t *e) {
 				return lv_event_get_draw_part_dsc(e);
 			}
 
@@ -1703,7 +1702,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      pointer to a draw context or NULL if called on an unrelated event
 		 */
-			static lv_draw_ctx_t *eventGetDrawContext(lv_event_t *e) {
+			static lv_draw_ctx_t *EventGetDrawContext(lv_event_t *e) {
 				return lv_event_get_draw_ctx(e);
 			}
 
@@ -1712,7 +1711,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      the old absolute area of the object or NULL if called on an unrelated event
 		 */
-			static const lv_area_t *eventGetOldSize(lv_event_t *e) {
+			static const lv_area_t *EventGetOldSize(lv_event_t *e) {
 				return lv_event_get_old_size(e);
 			}
 
@@ -1721,7 +1720,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      the triggering key or NULL if called on an unrelated event
 		 */
-			static uint32_t eventGetKey(lv_event_t *e) {
+			static uint32_t EventGetKey(lv_event_t *e) {
 				return lv_event_get_key(e);
 			}
 
@@ -1730,7 +1729,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      the animation that will scroll the object. (can be modified as required)
 		 */
-			static lv_anim_t *eventGetScrollAnim(lv_event_t *e) {
+			static lv_anim_t *EventGetScrollAnim(lv_event_t *e) {
 				return lv_event_get_scroll_anim(e);
 			}
 
@@ -1739,7 +1738,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @param size  The new extra draw size
 		 */
-			static void eventSetExtraDrawSize(lv_event_t *e, lv_coord_t size) {
+			static void EventSetExtraDrawSize(lv_event_t *e, lv_coord_t size) {
 				lv_event_set_ext_draw_size(e, size);
 			}
 
@@ -1749,7 +1748,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      pointer to `lv_point_t` or NULL if called on an unrelated event
 		 */
-			static lv_point_t *eventGetSelfSizeInfo(lv_event_t *e) {
+			static lv_point_t *EventGetSelfSizeInfo(lv_event_t *e) {
 				return lv_event_get_self_size_info(e);
 			}
 
@@ -1758,7 +1757,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      pointer to `lv_hit_test_info_t` or NULL if called on an unrelated event
 		 */
-			static lv_hit_test_info_t *eventGetHitTestInfo(lv_event_t *e) {
+			static lv_hit_test_info_t *EventGetHitTestInfo(lv_event_t *e) {
 				return lv_event_get_hit_test_info(e);
 			}
 
@@ -1768,7 +1767,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @return      an area with absolute coordinates to check
 		 */
-			static const lv_area_t *eventGetCoverArea(lv_event_t *e) {
+			static const lv_area_t *EventGetCoverArea(lv_event_t *e) {
 				return lv_event_get_cover_area(e);
 			}
 
@@ -1777,7 +1776,7 @@ namespace lvgl {
 		 * @param e     pointer to an event
 		 * @param res   an element of ::lv_cover_check_info_t
 		 */
-			static void eventSetCoverRes(lv_event_t *e, lv_cover_res_t res) {
+			static void EventSetCoverRes(lv_event_t *e, lv_cover_res_t res) {
 				lv_event_set_cover_res(e, res);
 			}
 

--- a/src/widgets/Roller.h
+++ b/src/widgets/Roller.h
@@ -1,8 +1,7 @@
 /*
  * Roller.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_ROLLER_H_
@@ -27,7 +26,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -41,15 +40,15 @@ namespace lvgl {
 			 * @param options   a string with '\n' separated options. E.g. "One\nTwo\nThree"
 			 * @param mode      `LV_ROLLER_MODE_NORMAL` or `LV_ROLLER_MODE_INFINITE`
 			 */
-			inline Roller *setOptions(const char * options, lv_roller_mode_t mode) {
+			inline Roller *SetOptions(const char * options, lv_roller_mode_t mode) {
 				lv_roller_set_options(_obj, options, mode);
 				return this;
 			}
-			inline Roller *setOptionsInfinite(const char * options) {
+			inline Roller *SetOptionsInfinite(const char * options) {
 				lv_roller_set_options(_obj, options, LV_ROLLER_MODE_INFINITE);
 				return this;
 			}
-			inline Roller *setOptionsNormal(const char * options) {
+			inline Roller *SetOptionsNormal(const char * options) {
 				lv_roller_set_options(_obj, options, LV_ROLLER_MODE_NORMAL);
 				return this;
 			}
@@ -60,7 +59,7 @@ namespace lvgl {
 			 * @param sel_opt   index of the selected option (0 ... number of option - 1);
 			 * @param anim_en   LV_ANIM_ON: set with animation; LV_ANOM_OFF set immediately
 			 */
-			inline Roller *setSelected(uint16_t sel_opt, lv_anim_enable_t anim) {
+			inline Roller *SetSelected(uint16_t sel_opt, lv_anim_enable_t anim) {
 				lv_roller_set_selected(_obj, sel_opt, anim);
 				return this;
 			}
@@ -70,7 +69,7 @@ namespace lvgl {
 			 * @param obj       pointer to a roller object
 			 * @param row_cnt   number of desired visible rows
 			 */
-			inline Roller *setVisibleRowCount(uint8_t row_cnt) {
+			inline Roller *SetVisibleRowCount(uint8_t row_cnt) {
 				lv_roller_set_visible_row_count(_obj, row_cnt);
 				return this;
 			}
@@ -84,7 +83,7 @@ namespace lvgl {
 			 * @param obj       pointer to a roller object
 			 * @return          index of the selected option (0 ... number of option - 1);
 			 */
-			inline uint16_t getSelected() {
+			inline uint16_t GetSelected() {
 				return lv_roller_get_selected((const lv_obj_t *)_obj);
 			}
 
@@ -94,7 +93,7 @@ namespace lvgl {
 			 * @param buf       pointer to an array to store the string
 			 * @param buf_size  size of `buf` in bytes. 0: to ignore it.
 			 */
-			inline Roller *getSelectedStr(char * buf, uint32_t buf_size) {
+			inline Roller *GetSelectedStr(char * buf, uint32_t buf_size) {
 				lv_roller_get_selected_str((const lv_obj_t *)_obj, buf, buf_size);
 				return this;
 			}
@@ -105,7 +104,7 @@ namespace lvgl {
 			 * @param obj       pointer to roller object
 			 * @return          the options separated by '\n'-s (E.g. "Option1\nOption2\nOption3")
 			 */
-			inline const char *getOptions() {
+			inline const char *GetOptions() {
 				return lv_roller_get_options((const lv_obj_t *)_obj);
 			}
 
@@ -114,7 +113,7 @@ namespace lvgl {
 			 * @param obj   pointer to a roller object
 			 * @return      the total number of options
 			 */
-			inline uint16_t getOptionCnt() {
+			inline uint16_t GetOptionCnt() {
 				return lv_roller_get_option_cnt((const lv_obj_t *)_obj);
 			}
 

--- a/src/widgets/Slider.h
+++ b/src/widgets/Slider.h
@@ -1,8 +1,7 @@
 /*
  * Slider.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_SLIDER_H_
@@ -27,7 +26,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -41,7 +40,7 @@ namespace lvgl {
 			 * @param value     the new value
 			 * @param anim      LV_ANIM_ON: set the value with an animation; LV_ANIM_OFF: change the value immediately
 			 */
-			inline Slider *setValue(int32_t value, lv_anim_enable_t anim) {
+			inline Slider *SetValue(int32_t value, lv_anim_enable_t anim) {
 				lv_bar_set_value(_obj, value, anim);
 				return this;
 			}
@@ -52,7 +51,7 @@ namespace lvgl {
 			 * @param value     new value
 			 * @param anim      LV_ANIM_ON: set the value with an animation; LV_ANIM_OFF: change the value immediately
 			 */
-			inline Slider *setLeftValue(int32_t value, lv_anim_enable_t anim) {
+			inline Slider *SetLeftValue(int32_t value, lv_anim_enable_t anim) {
 				lv_bar_set_start_value(_obj, value, anim);
 				return this;
 			}
@@ -63,7 +62,7 @@ namespace lvgl {
 			 * @param min       minimum value
 			 * @param max       maximum value
 			 */
-			inline Slider *setRange(int32_t min, int32_t max) {
+			inline Slider *SetRange(int32_t min, int32_t max) {
 				lv_bar_set_range(_obj, min, max);
 				return this;
 			}
@@ -73,7 +72,7 @@ namespace lvgl {
 			 * @param obj       pointer to a slider object
 			 * @param mode      the mode of the slider. See ::lv_slider_mode_t
 			 */
-			inline Slider *setMode(lv_slider_mode_t mode) {
+			inline Slider *SetMode(lv_slider_mode_t mode) {
 				lv_bar_set_mode(_obj, (lv_bar_mode_t)mode);
 				return this;
 			}
@@ -87,7 +86,7 @@ namespace lvgl {
 			 * @param obj       pointer to a slider object
 			 * @return          the value of the main knob of the slider
 			 */
-			inline int32_t getValue() {
+			inline int32_t GetValue() {
 				return lv_bar_get_value((const lv_obj_t *)_obj);
 			}
 
@@ -96,7 +95,7 @@ namespace lvgl {
 			 * @param obj       pointer to a slider object
 			 * @return          the value of the left knob of the slider
 			 */
-			inline int32_t getLeftValue() {
+			inline int32_t GetLeftValue() {
 				return lv_bar_get_start_value((const lv_obj_t *)_obj);
 			}
 
@@ -105,7 +104,7 @@ namespace lvgl {
 			 * @param obj       pointer to a slider object
 			 * @return          the minimum value of the slider
 			 */
-			inline int32_t getMinValue() {
+			inline int32_t GetMinValue() {
 				return lv_bar_get_min_value((const lv_obj_t *)_obj);
 			}
 
@@ -114,7 +113,7 @@ namespace lvgl {
 			 * @param obj       pointer to a slider object
 			 * @return          the maximum value of the slider
 			 */
-			inline int32_t getMaxValue(const lv_obj_t * obj) {
+			inline int32_t GetMaxValue(const lv_obj_t * obj) {
 				return lv_bar_get_max_value((const lv_obj_t *)_obj);
 			}
 
@@ -123,7 +122,7 @@ namespace lvgl {
 			 * @param obj       pointer to a slider object
 			 * @return          true: drag in progress false: not dragged
 			 */
-			inline bool isDragged() {
+			inline bool IsDragged() {
 				return lv_slider_is_dragged((const lv_obj_t *)_obj);
 			}
 
@@ -132,7 +131,7 @@ namespace lvgl {
 			 * @param obj       pointer to a bar object
 			 * @return          see ::lv_slider_mode_t
 			 */
-			inline lv_slider_mode_t getMode() {
+			inline lv_slider_mode_t GetMode() {
 				lv_bar_mode_t mode = lv_bar_get_mode(_obj);
 				if(mode == LV_BAR_MODE_SYMMETRICAL) return LV_SLIDER_MODE_SYMMETRICAL;
 				else if(mode == LV_BAR_MODE_RANGE) return LV_SLIDER_MODE_RANGE;

--- a/src/widgets/Style.h
+++ b/src/widgets/Style.h
@@ -1,3 +1,8 @@
+/*
+ * Style.h
+ *
+ *      Author: Iulian Gheorghiu
+ */
 #ifndef LVGLCPP_SRC_H_
 #define LVGLCPP_SRC_H_
 
@@ -10,7 +15,7 @@ namespace lvgl {
 			Prop() {
 				memset(prop, LV_STYLE_PROP_INV, sizeof(prop));
 			}
-			lvgl::style::Prop *add(lv_style_prop_t p) {
+			Prop *Add(lv_style_prop_t p) {
 				int i = 0;
 				for(; i < sizeof(prop) - 1; i++) {
 					if(prop[i] == p) {
@@ -24,7 +29,7 @@ namespace lvgl {
 				}
 				return this;
 			}
-			lvgl::style::Prop *remove(lv_style_prop_t p) {
+			Prop *Remove(lv_style_prop_t p) {
 				int i = 0;
 				bool found = false;
 				for(; i < sizeof(prop) - 1; i++) {
@@ -38,7 +43,7 @@ namespace lvgl {
 				}
 				return this;
 			}
-			lvgl::style::Prop *remove(int idx) {
+			Prop *Remove(int idx) {
 				int i = 0;
 				bool found = false;
 				for(; i < sizeof(prop) - 1; i++) {
@@ -52,7 +57,7 @@ namespace lvgl {
 				}
 				return this;
 			}
-			const lv_style_prop_t *get() {
+			const lv_style_prop_t *Get() {
 				return prop;
 			}
 		private:
@@ -61,48 +66,48 @@ namespace lvgl {
 //------------------------------------------
 		class Transition {
 		public:
-			Transition(lvgl::style::Prop *prop, lv_anim_path_cb_t path_cb, uint32_t time = 250, uint32_t delay = 0, void * user_data = NULL) {
-				lv_style_transition_dsc_init(&transitionDef, prop->get(), path_cb, time, delay, user_data);
+			Transition(Prop *prop, lv_anim_path_cb_t path_cb, uint32_t time = 250, uint32_t delay = 0, void * user_data = NULL) {
+				lv_style_transition_dsc_init(&transitionDef, prop->Get(), path_cb, time, delay, user_data);
 			}
-			Transition(lvgl::style::Prop prop, lv_anim_path_cb_t path_cb, uint32_t time = 250, uint32_t delay = 0, void * user_data = NULL) {
-				lv_style_transition_dsc_init(&transitionDef, prop.get(), path_cb, time, delay, user_data);
+			Transition(Prop prop, lv_anim_path_cb_t path_cb, uint32_t time = 250, uint32_t delay = 0, void * user_data = NULL) {
+				lv_style_transition_dsc_init(&transitionDef, prop.Get(), path_cb, time, delay, user_data);
 			}
 			Transition(const lv_style_prop_t *prop, lv_anim_path_cb_t path_cb, uint32_t time = 250, uint32_t delay = 0, void * user_data = NULL) {
 				lv_style_transition_dsc_init(&transitionDef, prop, path_cb, time, delay, user_data);
 			}
-			lvgl::style::Transition *setCb(lv_anim_path_cb_t path_cb) {
+			Transition *SetCb(lv_anim_path_cb_t path_cb) {
 				pathCb = path_cb;
 				return this;
 			}
-			lv_anim_path_cb_t getCb() {
+			lv_anim_path_cb_t GetCb() {
 				return pathCb;
 			}
-			lvgl::style::Transition *setTime(uint32_t time) {
+			Transition *SetTime(uint32_t time) {
 				this->time = time;
 				return this;
 			}
 			uint32_t getTime() {
 				return time;
 			}
-			lvgl::style::Transition *setDelay(uint32_t delay) {
+			Transition *SetDelay(uint32_t delay) {
 				this->delay = delay;
 				return this;
 			}
 			uint32_t getDelay() {
 				return delay;
 			}
-			lvgl::style::Transition *setUserData(void * userData) {
+			Transition *SetUserData(void * userData) {
 				this->userData = userData;
 				return this;
 			}
-			void *getUserData() {
+			void *GetUserData() {
 				return userData;
 			}
-			lvgl::style::Transition *setTransitionDef(lv_style_transition_dsc_t transitionDef) {
+			Transition *SetTransitionDef(lv_style_transition_dsc_t transitionDef) {
 				this->transitionDef = transitionDef;
 				return this;
 			}
-			lv_style_transition_dsc_t *get() {
+			lv_style_transition_dsc_t *Get() {
 				return &transitionDef;
 			}
 		private:
@@ -119,377 +124,377 @@ namespace lvgl {
 		Style() {
 			lv_style_init(&style);
 		}
-		lv_style_t *get() {
+		lv_style_t *Get() {
 			return &style;
 		}
 		
 		
-		lvgl::Style *setWidth(lv_coord_t value) {
+		Style *SetWidth(lv_coord_t value) {
 			lv_style_set_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setMinWidth(lv_coord_t value) {
+		Style *SetMinWidth(lv_coord_t value) {
 			lv_style_set_min_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setMaxWidth(lv_coord_t value) {
+		Style *SetMaxWidth(lv_coord_t value) {
 			lv_style_set_max_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setHeight(lv_coord_t value) {
+		Style *SetHeight(lv_coord_t value) {
 			lv_style_set_height(&style, value);
 			return this;
 		}
-		lvgl::Style *setMinHeight(lv_coord_t value) {
+		Style *SetMinHeight(lv_coord_t value) {
 			lv_style_set_min_height(&style, value);
 			return this;
 		}
-		lvgl::Style *setMaxHeight(lv_coord_t value) {
+		Style *SetMaxHeight(lv_coord_t value) {
 			lv_style_set_max_height(&style, value);
 			return this;
 		}
-		lvgl::Style *setX(lv_coord_t value) {
+		Style *SetX(lv_coord_t value) {
 			lv_style_set_x(&style, value);
 			return this;
 		}
-		lvgl::Style *setY(lv_coord_t value) {
+		Style *SetY(lv_coord_t value) {
 			lv_style_set_y(&style, value);
 			return this;
 		}
-		lvgl::Style *setAlign(lv_align_t value) {
+		Style *SetAlign(lv_align_t value) {
 			lv_style_set_align(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransformWidth(lv_coord_t value) {
+		Style *SetTransformWidth(lv_coord_t value) {
 			lv_style_set_transform_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransformHeight(lv_coord_t value) {
+		Style *SetTransformHeight(lv_coord_t value) {
 			lv_style_set_transform_height(&style, value);
 			return this;
 		}
-		lvgl::Style *setTranslateX(lv_coord_t value) {
+		Style *SetTranslateX(lv_coord_t value) {
 			lv_style_set_translate_x(&style, value);
 			return this;
 		}
-		lvgl::Style *setTranslateY(lv_coord_t value) {
+		Style *SetTranslateY(lv_coord_t value) {
 			lv_style_set_translate_y(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransformZoom(lv_coord_t value) {
+		Style *SetTransformZoom(lv_coord_t value) {
 			lv_style_set_transform_zoom(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransformAngle(lv_coord_t value) {
+		Style *SetTransformAngle(lv_coord_t value) {
 			lv_style_set_transform_angle(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransformPivotX(lv_coord_t value) {
+		Style *SetTransformPivotX(lv_coord_t value) {
 			lv_style_set_transform_pivot_x(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransformPivotY(lv_coord_t value) {
+		Style *SetTransformPivotY(lv_coord_t value) {
 			lv_style_set_transform_pivot_y(&style, value);
 			return this;
 		}
-		lvgl::Style *setPadTop(lv_coord_t value) {
+		Style *SetPadTop(lv_coord_t value) {
 			lv_style_set_pad_top(&style, value);
 			return this;
 		}
-		lvgl::Style *setPadBottom(lv_coord_t value) {
+		Style *SetPadBottom(lv_coord_t value) {
 			lv_style_set_pad_bottom(&style, value);
 			return this;
 		}
-		lvgl::Style *setPadLeft(lv_coord_t value) {
+		Style *SetPadLeft(lv_coord_t value) {
 			lv_style_set_pad_left(&style, value);
 			return this;
 		}
-		lvgl::Style *setPadRight(lv_coord_t value) {
+		Style *SetPadRight(lv_coord_t value) {
 			lv_style_set_pad_right(&style, value);
 			return this;
 		}
-		lvgl::Style *setPadRow(lv_coord_t value) {
+		Style *SetPadRow(lv_coord_t value) {
 			lv_style_set_pad_row(&style, value);
 			return this;
 		}
-		lvgl::Style *setPadColumn(lv_coord_t value) {
+		Style *SetPadColumn(lv_coord_t value) {
 			lv_style_set_pad_column(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgColor(lv_color_t value) {
+		Style *SetBgColor(lv_color_t value) {
 			lv_style_set_bg_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgOpacity(lv_opa_t value) {
+		Style *SetBgOpacity(lv_opa_t value) {
 			lv_style_set_bg_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgGradientColor(lv_color_t value) {
+		Style *SetBgGradientColor(lv_color_t value) {
 			lv_style_set_bg_grad_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgGradientDirection(lv_grad_dir_t value) {
+		Style *SetBgGradientDirection(lv_grad_dir_t value) {
 			lv_style_set_bg_grad_dir(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgMainStop(lv_coord_t value) {
+		Style *SetBgMainStop(lv_coord_t value) {
 			lv_style_set_bg_main_stop(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgGradientStop(lv_coord_t value) {
+		Style *SetBgGradientStop(lv_coord_t value) {
 			lv_style_set_bg_grad_stop(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgGradient(const lv_grad_dsc_t * value) {
+		Style *SetBgGradient(const lv_grad_dsc_t * value) {
 			lv_style_set_bg_grad(&style,value);
 			return this;
 		}
-		lvgl::Style *setBgDitherMode(lv_dither_mode_t value) {
+		Style *SetBgDitherMode(lv_dither_mode_t value) {
 			lv_style_set_bg_dither_mode(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgImageSource(const lvgl::Style ** value) {
+		Style *SetBgImageSource(const Style ** value) {
 			lv_style_set_bg_img_src(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgImageOpacity(lv_opa_t value) {
+		Style *SetBgImageOpacity(lv_opa_t value) {
 			lv_style_set_bg_img_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgImageReColor(lv_color_t value) {
+		Style *SetBgImageReColor(lv_color_t value) {
 			lv_style_set_bg_img_recolor(&style, value);
 			return this;
 		}
-		lvgl::Style *setImageBgReColorOpacity(lv_opa_t value) {
+		Style *SetImageBgReColorOpacity(lv_opa_t value) {
 			lv_style_set_bg_img_recolor_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setBgImageTiled(bool value) {
+		Style *SetBgImageTiled(bool value) {
 			lv_style_set_bg_img_tiled(&style, value);
 			return this;
 		}
-		lvgl::Style *setBorderColor(lv_color_t value) {
+		Style *SetBorderColor(lv_color_t value) {
 			lv_style_set_border_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setBorderOpacity(lv_opa_t value) {
+		Style *SetBorderOpacity(lv_opa_t value) {
 			lv_style_set_border_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setBorderWidth(lv_coord_t value) {
+		Style *SetBorderWidth(lv_coord_t value) {
 			lv_style_set_border_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setBorderSide(lv_border_side_t value) {
+		Style *SetBorderSide(lv_border_side_t value) {
 			lv_style_set_border_side(&style, value);
 			return this;
 		}
-		lvgl::Style *setBorderPost(bool value) {
+		Style *SetBorderPost(bool value) {
 			lv_style_set_border_post(&style, value);
 			return this;
 		}
-		lvgl::Style *setOutlineWidth(lv_coord_t value) {
+		Style *SetOutlineWidth(lv_coord_t value) {
 			lv_style_set_outline_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setOutlineColor(lv_color_t value) {
+		Style *SetOutlineColor(lv_color_t value) {
 			lv_style_set_outline_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setOutlineOpacity(lv_opa_t value) {
+		Style *SetOutlineOpacity(lv_opa_t value) {
 			lv_style_set_outline_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setOutlinePad(lv_coord_t value) {
+		Style *SetOutlinePad(lv_coord_t value) {
 			lv_style_set_outline_pad(&style, value);
 			return this;
 		}
-		lvgl::Style *setShadowWidth(lv_coord_t value) {
+		Style *SetShadowWidth(lv_coord_t value) {
 			lv_style_set_shadow_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setShadowOffsetX(lv_coord_t value) {
+		Style *SetShadowOffsetX(lv_coord_t value) {
 			lv_style_set_shadow_ofs_x(&style, value);
 			return this;
 		}
-		lvgl::Style *setShadowOffsetY(lv_coord_t value) {
+		Style *SetShadowOffsetY(lv_coord_t value) {
 			lv_style_set_shadow_ofs_y(&style, value);
 			return this;
 		}
-		lvgl::Style *setShadowSpread(lv_coord_t value) {
+		Style *SetShadowSpread(lv_coord_t value) {
 			lv_style_set_shadow_spread(&style, value);
 			return this;
 		}
-		lvgl::Style *setShadowColor(lv_color_t value) {
+		Style *SetShadowColor(lv_color_t value) {
 			lv_style_set_shadow_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setShadowOpacity(lv_opa_t value) {
+		Style *SetShadowOpacity(lv_opa_t value) {
 			lv_style_set_shadow_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setImageOpacity(lv_opa_t value) {
+		Style *SetImageOpacity(lv_opa_t value) {
 			lv_style_set_img_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setImageReColor(lv_color_t value) {
+		Style *SetImageReColor(lv_color_t value) {
 			lv_style_set_img_recolor(&style, value);
 			return this;
 		}
-		lvgl::Style *setImageReColorOpacity(lv_opa_t value) {
+		Style *SetImageReColorOpacity(lv_opa_t value) {
 			lv_style_set_img_recolor_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setLineWidth(lv_coord_t value) {
+		Style *SetLineWidth(lv_coord_t value) {
 			lv_style_set_line_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setLineDashWidth(lv_coord_t value) {
+		Style *SetLineDashWidth(lv_coord_t value) {
 			lv_style_set_line_dash_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setLineDashGap(lv_coord_t value) {
+		Style *SetLineDashGap(lv_coord_t value) {
 			lv_style_set_line_dash_gap(&style, value);
 			return this;
 		}
-		lvgl::Style *setLineRounded(bool value) {
+		Style *SetLineRounded(bool value) {
 			lv_style_set_line_rounded(&style, value);
 			return this;
 		}
-		lvgl::Style *setLineColor(lv_color_t value) {
+		Style *SetLineColor(lv_color_t value) {
 			lv_style_set_line_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setLineOpacity(lv_opa_t value) {
+		Style *SetLineOpacity(lv_opa_t value) {
 			lv_style_set_line_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setArcWidth(lv_coord_t value) {
+		Style *SetArcWidth(lv_coord_t value) {
 			lv_style_set_arc_width(&style, value);
 			return this;
 		}
-		lvgl::Style *setArcRounded(bool value) {
+		Style *SetArcRounded(bool value) {
 			lv_style_set_arc_rounded(&style, value);
 			return this;
 		}
-		lvgl::Style *setArcColor(lv_color_t value) {
+		Style *SetArcColor(lv_color_t value) {
 			lv_style_set_arc_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setArcOpacity(lv_opa_t value) {
+		Style *SetArcOpacity(lv_opa_t value) {
 			lv_style_set_arc_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setArcImageSource(const lvgl::Style ** value) {
+		Style *SetArcImageSource(const Style ** value) {
 			lv_style_set_arc_img_src(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextColor(lv_color_t value) {
+		Style *SetTextColor(lv_color_t value) {
 			lv_style_set_text_color(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextOpacity(lv_opa_t value) {
+		Style *SetTextOpacity(lv_opa_t value) {
 			lv_style_set_text_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextFont(const lv_font_t * value) {
+		Style *SetTextFont(const lv_font_t * value) {
 			lv_style_set_text_font(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextLetterSpace(lv_coord_t value) {
+		Style *SetTextLetterSpace(lv_coord_t value) {
 			lv_style_set_text_letter_space(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextLineSpace(lv_coord_t value) {
+		Style *SetTextLineSpace(lv_coord_t value) {
 			lv_style_set_text_line_space(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextDecor(lv_text_decor_t value) {
+		Style *SetTextDecor(lv_text_decor_t value) {
 			lv_style_set_text_decor(&style, value);
 			return this;
 		}
-		lvgl::Style *setTextAlign(lv_coord_t value) {
+		Style *SetTextAlign(lv_coord_t value) {
 			lv_style_set_text_align(&style, value);
 			return this;
 		}
-		lvgl::Style *setRadius(lv_coord_t value) {
+		Style *SetRadius(lv_coord_t value) {
 			lv_style_set_radius(&style, value);
 			return this;
 		}
-		lvgl::Style *setClipCorner(bool value) {
+		Style *SetClipCorner(bool value) {
 			lv_style_set_clip_corner(&style, value);
 			return this;
 		}
-		lvgl::Style *setOpacity(lv_opa_t value) {
+		Style *SetOpacity(lv_opa_t value) {
 			lv_style_set_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setOpacityLayered(lv_opa_t value) {
+		Style *SetOpacityLayered(lv_opa_t value) {
 			lv_style_set_opa_layered(&style, value);
 			return this;
 		}
-		lvgl::Style *setColorFilterDsc(const lv_color_filter_dsc_t * value) {
+		Style *SetColorFilterDsc(const lv_color_filter_dsc_t * value) {
 			lv_style_set_color_filter_dsc(&style, value);
 			return this;
 		}
-		lvgl::Style *setColorFilterOpacity(lv_opa_t value) {
+		Style *SetColorFilterOpacity(lv_opa_t value) {
 			lv_style_set_color_filter_opa(&style, value);
 			return this;
 		}
-		lvgl::Style *setAnimation(const lv_anim_t * value) {
+		Style *SetAnimation(const lv_anim_t * value) {
 			lv_style_set_anim(&style, value);
 			return this;
 		}
-		lvgl::Style *setAnimationTime(uint32_t value) {
+		Style *SetAnimationTime(uint32_t value) {
 			lv_style_set_anim_time(&style, value);
 			return this;
 		}
-		lvgl::Style *setAnimationSpeed(uint32_t value) {
+		Style *SetAnimationSpeed(uint32_t value) {
 			lv_style_set_anim_speed(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransition(const lv_style_transition_dsc_t * value) {
+		Style *SetTransition(const lv_style_transition_dsc_t *value) {
 			lv_style_set_transition(&style, value);
 			return this;
 		}
-		lvgl::Style *setTransition(lvgl::style::Transition *value) {
-			lv_style_set_transition(&style, value->get());
+		Style *SetTransition(lvgl::style::Transition *value) {
+			lv_style_set_transition(&style, value->Get());
 			return this;
 		}
-		lvgl::Style *setTransition(lvgl::style::Transition value) {
-			lv_style_set_transition(&style, value.get());
+		Style *SetTransition(lvgl::style::Transition value) {
+			lv_style_set_transition(&style, value.Get());
 			return this;
 		}
-		lvgl::Style *setBlendMode(lv_blend_mode_t value) {
+		Style *SetBlendMode(lv_blend_mode_t value) {
 			lv_style_set_blend_mode(&style, value);
 			return this;
 		}
-		lvgl::Style *setLayout(uint16_t value) {
+		Style *SetLayout(uint16_t value) {
 			lv_style_set_layout(&style, value);
 			return this;
 		}
-		lvgl::Style *setBaseDirection(lv_base_dir_t value) {
+		Style *SetBaseDirection(lv_base_dir_t value) {
 			lv_style_set_base_dir(&style, value);
 			return this;
 		}
 		
-		lvgl::Style *setFlexFlow(lv_flex_flow_t value) {
+		Style *SetFlexFlow(lv_flex_flow_t value) {
 			lv_style_set_flex_flow(&style, value);
 			return this;
 		}
-		lvgl::Style *setFlexMainPlace(lv_flex_align_t value) {
+		Style *SetFlexMainPlace(lv_flex_align_t value) {
 			lv_style_set_flex_main_place(&style, value);
 			return this;
 		}
-		lvgl::Style *setFlexCrossPlace(lv_flex_align_t value) {
+		Style *SetFlexCrossPlace(lv_flex_align_t value) {
 			lv_style_set_flex_cross_place(&style, value);
 			return this;
 		}
-		lvgl::Style *setFlexTrackPlace(lv_flex_align_t value) {
+		Style *SetFlexTrackPlace(lv_flex_align_t value) {
 			lv_style_set_flex_track_place(&style, value);
 			return this;
 		}
-		lvgl::Style *setFlexGrow(uint8_t value) {
+		Style *SetFlexGrow(uint8_t value) {
 			lv_style_set_flex_grow(&style, value);
 			return this;
 		}

--- a/src/widgets/Switch.h
+++ b/src/widgets/Switch.h
@@ -1,8 +1,7 @@
 /*
  * Switch.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_SWITCH_H_
@@ -27,7 +26,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 

--- a/src/widgets/TabView.h
+++ b/src/widgets/TabView.h
@@ -1,8 +1,7 @@
 /*
- * tabView.h
+ * TabView.h
  *
- *  Created on: Nov 25, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_TABVIEW_H_
@@ -24,7 +23,7 @@ namespace lvgl {
 					_obj = lv_tabview_create(lv_scr_act(), tabPos, tabSize);
 				}
 				_btns = new ButtonMatrix();
-				_btns->setObj(lv_tabview_get_tab_btns(_obj));
+				_btns->SetObj(lv_tabview_get_tab_btns(_obj));
 				_child = NULL;
 				_childs = (lv_obj_t **)calloc(1, sizeof(lv_obj_t *));
 			}
@@ -33,15 +32,15 @@ namespace lvgl {
 				// TODO Auto-generated destructor stub
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
-			inline 	ButtonMatrix *getBtns() {
+			inline 	ButtonMatrix *GetBtns() {
 				return _btns;
 			}
 
-			inline TabView *addTab(const char *name) {
+			inline TabView *AddTab(const char *name) {
 				uint32_t i = 0;
 				for(; i < (uint32_t)-1; i++) {
 					if(!_childs[i])
@@ -53,7 +52,7 @@ namespace lvgl {
 				return this;
 			}
 
-			inline lv_obj_t *getTabObj(uint32_t id) {
+			inline lv_obj_t *GetTabObj(uint32_t id) {
 				int i = 0;
 				for(; _childs[i] != NULL; i++);
 				if(id < i) {
@@ -62,11 +61,11 @@ namespace lvgl {
 				return NULL;
 			}
 
-			inline lv_obj_t *getTabObj(const char *name) {
+			inline lv_obj_t *GetTabObj(const char *name) {
 				int i = 0;
 				for(; _childs[i] != NULL; i++);
 				for(int j = 0; j < i; j++) {
-					const char *txt = lv_btnmatrix_get_btn_text((const lv_obj_t *)_btns->getObj(), j);
+					const char *txt = lv_btnmatrix_get_btn_text((const lv_obj_t *)_btns->GetObj(), j);
 					if(!strcmp(txt, name))
 						return _childs[j];
 				}
@@ -75,21 +74,21 @@ namespace lvgl {
 
 
 
-			inline TabView *renameTab(uint32_t tab_id, const char * new_name) {
+			inline TabView *RenameTab(uint32_t tab_id, const char * new_name) {
 				lv_tabview_rename_tab(_obj, tab_id, new_name);
 				return this;
 			}
-			inline lv_obj_t *getContent() {
+			inline lv_obj_t *GetContent() {
 				return lv_tabview_get_content(_obj);
 			}
-			inline lv_obj_t *getTabBtns() {
+			inline lv_obj_t *GetTabBtns() {
 				return lv_tabview_get_tab_btns(_obj);
 			}
-			inline TabView *setAct(uint32_t id, lv_anim_enable_t anim_en) {
+			inline TabView *SetActiveTab(uint32_t id, lv_anim_enable_t anim_en) {
 				lv_tabview_set_act(_obj, id, anim_en);
 				return this;
 			}
-			inline uint16_t getTabAct() {
+			inline uint16_t GetActiveTab() {
 				return lv_tabview_get_tab_act(_obj);
 			}
 		};

--- a/src/widgets/Table.h
+++ b/src/widgets/Table.h
@@ -1,8 +1,7 @@
 /*
  * Table.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_TABLE_H_
@@ -30,7 +29,7 @@ namespace lvgl {
 
 			}
 
-			inline lv_obj_t *getObj() {
+			inline lv_obj_t *GetObj() {
 				return _obj;
 			}
 
@@ -46,7 +45,7 @@ namespace lvgl {
 			 * @param txt           text to display in the cell. It will be copied and saved so this variable is not required after this function call.
 			 * @note                New roes/columns are added automatically if required
 			 */
-			Table *setCellValue(uint16_t row, uint16_t col, const char * fmt, ...) {
+			Table *SetCellValue(uint16_t row, uint16_t col, const char * fmt, ...) {
 				va_list args;
 				va_start(args, fmt);
 				int size = vsnprintf(NULL, 0, fmt, args);
@@ -64,7 +63,7 @@ namespace lvgl {
 			 * @param obj           table pointer to a Table object
 			 * @param row_cnt       number of rows
 			 */
-			inline Table *setRowCount(uint16_t row_cnt) {
+			inline Table *SetRowCount(uint16_t row_cnt) {
 				lv_table_set_row_cnt(_obj, row_cnt);
 				return this;
 			}
@@ -74,7 +73,7 @@ namespace lvgl {
 			 * @param obj       table pointer to a Table object
 			 * @param col_cnt   number of columns.
 			 */
-			inline Table *setColCount(uint16_t col_cnt) {
+			inline Table *SetColCount(uint16_t col_cnt) {
 				lv_table_set_col_cnt(_obj, col_cnt);
 				return this;
 			}
@@ -85,7 +84,7 @@ namespace lvgl {
 			 * @param col_id    id of the column [0 .. LV_TABLE_COL_MAX -1]
 			 * @param w         width of the column
 			 */
-			inline Table *setColWidth(uint16_t col_id, lv_coord_t w) {
+			inline Table *SetColWidth(uint16_t col_id, lv_coord_t w) {
 				lv_table_set_col_width(_obj, col_id, w);
 				return this;
 			}
@@ -97,7 +96,7 @@ namespace lvgl {
 			 * @param col       id of the column [0 .. col_cnt -1]
 			 * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
 			 */
-			inline Table *addCellCtrl(uint16_t row, uint16_t col, lv_table_cell_ctrl_t ctrl) {
+			inline Table *AddCellCtrl(uint16_t row, uint16_t col, lv_table_cell_ctrl_t ctrl) {
 				lv_table_add_cell_ctrl(_obj, row, col, ctrl);
 				return this;
 			}
@@ -110,7 +109,7 @@ namespace lvgl {
 			 * @param col       id of the column [0 .. col_cnt -1]
 			 * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
 			 */
-			inline Table *clearCellCtrl(uint16_t row, uint16_t col, lv_table_cell_ctrl_t ctrl) {
+			inline Table *ClearCellCtrl(uint16_t row, uint16_t col, lv_table_cell_ctrl_t ctrl) {
 				lv_table_clear_cell_ctrl(_obj, row, col, ctrl);
 				return this;
 			}
@@ -126,7 +125,7 @@ namespace lvgl {
 			 * @param col       id of the column [0 .. col_cnt -1]
 			 * @return          text in the cell
 			 */
-			inline const char *getCellValue(uint16_t row, uint16_t col) {
+			inline const char *GetCellValue(uint16_t row, uint16_t col) {
 				return lv_table_get_cell_value(_obj, row, col);
 			}
 
@@ -135,7 +134,7 @@ namespace lvgl {
 			 * @param obj       table pointer to a Table object
 			 * @return          number of rows.
 			 */
-			inline uint16_t getRowCount() {
+			inline uint16_t GetRowCount() {
 				return lv_table_get_row_cnt(_obj);
 			}
 
@@ -144,7 +143,7 @@ namespace lvgl {
 			 * @param obj       table pointer to a Table object
 			 * @return          number of columns.
 			 */
-			inline uint16_t getColCount() {
+			inline uint16_t GetColCount() {
 				return lv_table_get_col_cnt(_obj);
 			}
 
@@ -154,7 +153,7 @@ namespace lvgl {
 			 * @param col       id of the column [0 .. LV_TABLE_COL_MAX -1]
 			 * @return          width of the column
 			 */
-			inline lv_coord_t getColWidth(uint16_t col) {
+			inline lv_coord_t GetColWidth(uint16_t col) {
 				return lv_table_get_col_width(_obj, col);
 			}
 
@@ -166,7 +165,7 @@ namespace lvgl {
 			 * @param ctrl      OR-ed values from ::lv_table_cell_ctrl_t
 			 * @return          true: all control bits are set; false: not all control bits are set
 			 */
-			inline bool hasCellCtrl(uint16_t row, uint16_t col, lv_table_cell_ctrl_t ctrl) {
+			inline bool HasCellCtrl(uint16_t row, uint16_t col, lv_table_cell_ctrl_t ctrl) {
 				return lv_table_has_cell_ctrl(_obj, row, col, ctrl);
 			}
 
@@ -176,7 +175,7 @@ namespace lvgl {
 			 * @param row       pointer to variable to store the selected row (LV_TABLE_CELL_NONE: if no cell selected)
 			 * @param col       pointer to variable to store the selected column  (LV_TABLE_CELL_NONE: if no cell selected)
 			 */
-			inline Table *getSelectedCell(uint16_t * row, uint16_t * col) {
+			inline Table *GetSelectedCell(uint16_t * row, uint16_t * col) {
 				lv_table_get_selected_cell(_obj, row, col);
 				return this;
 			}

--- a/src/widgets/TextArea.h
+++ b/src/widgets/TextArea.h
@@ -1,8 +1,7 @@
 /*
  * TextArea.h
  *
- *  Created on: Nov 27, 2023
- *      Author: morgoth
+ *      Author: Iulian Gheorghiu
  */
 
 #ifndef LVGLCPP_SRC_TEXTAREA_H_
@@ -92,7 +91,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param txt       pointer to the text
 			 */
-			TextArea *setText(const char * fmt, ...) {
+			TextArea *SetText(const char * fmt, ...) {
 				va_list args;
 				va_start(args, fmt);
 				int size = vsnprintf(NULL, 0, fmt, args);
@@ -110,7 +109,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param txt       pointer to the text
 			 */
-			TextArea *setPlaceholderText(const char * fmt, ...) {
+			TextArea *SetPlaceholderText(const char * fmt, ...) {
 				va_list args;
 				va_start(args, fmt);
 				int size = vsnprintf(NULL, 0, fmt, args);
@@ -130,7 +129,7 @@ namespace lvgl {
 			 *                  < 0 : index from the end of the text
 			 *                  LV_TEXTAREA_CURSOR_LAST: go after the last character
 			 */
-			inline TextArea *setCursorPos(int32_t pos) {
+			inline TextArea *SetCursorPos(int32_t pos) {
 				lv_textarea_set_cursor_pos(_obj, pos);
 				return this;
 			}
@@ -140,7 +139,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param en        true: enable click positions; false: disable
 			 */
-			inline TextArea *setCursorClickPos(bool en) {
+			inline TextArea *SetCursorClickPos(bool en) {
 				lv_textarea_set_cursor_click_pos(_obj, en);
 				return this;
 			}
@@ -150,7 +149,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param en        true: enable, false: disable
 			 */
-			inline TextArea *setPasswordMode(bool en) {
+			inline TextArea *SetPasswordMode(bool en) {
 				lv_textarea_set_password_mode(_obj, en);
 				return this;
 			}
@@ -160,7 +159,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param bullet    pointer to the replacement text
 			 */
-			inline TextArea *setPasswordBullet(const char *bullet) {
+			inline TextArea *SetPasswordBullet(const char *bullet) {
 				lv_textarea_set_password_bullet(_obj, bullet);
 				return this;
 			}
@@ -170,7 +169,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param en        true: one line, false: normal
 			 */
-			inline TextArea *setOneLine(bool en) {
+			inline TextArea *SetOneLine(bool en) {
 				lv_textarea_set_one_line(_obj, en);
 				return this;
 			}
@@ -180,7 +179,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param list      list of characters. Only the pointer is saved. E.g. "+-.,0123456789"
 			 */
-			inline TextArea *setAcceptedChars(const char *list) {
+			inline TextArea *SetAcceptedChars(const char *list) {
 				lv_textarea_set_accepted_chars(_obj, list);
 				return this;
 			}
@@ -190,7 +189,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param num       the maximal number of characters can be added (`lv_textarea_set_text` ignores it)
 			 */
-			inline TextArea *setMaxLength(uint32_t num) {
+			inline TextArea *SetMaxLength(uint32_t num) {
 				lv_textarea_set_max_length(_obj, num);
 				return this;
 			}
@@ -202,7 +201,7 @@ namespace lvgl {
 			 * @param txt       pointer to a new string to insert. If `""` no text will be added.
 			 *                  The variable must be live after the `event_cb` exists. (Should be `global` or `static`)
 			 */
-			inline TextArea *setInsertReplace(const char * txt) {
+			inline TextArea *SetInsertReplace(const char * txt) {
 				lv_textarea_set_insert_replace(_obj, txt);
 				return this;
 			}
@@ -212,7 +211,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param en        true or false to enable/disable selection mode
 			 */
-			inline TextArea *setTextSelection(bool en) {
+			inline TextArea *SetTextSelection(bool en) {
 				lv_textarea_set_text_selection(_obj, en);
 				return this;
 			}
@@ -222,7 +221,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param time      show time in milliseconds. 0: hide immediately.
 			 */
-			inline TextArea *setPasswordShowTime(uint16_t ms) {
+			inline TextArea *SetPasswordShowTime(uint16_t ms) {
 				lv_textarea_set_password_show_time(_obj, ms);
 				return this;
 			}
@@ -235,7 +234,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @param align     the align mode from ::lv_text_align_t
 			 */
-			inline TextArea *setAlign(lv_text_align_t align) {
+			inline TextArea *SetAlign(lv_text_align_t align) {
 				lv_textarea_set_align(_obj, align);
 				return this;
 			}
@@ -249,7 +248,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          pointer to the text
 			 */
-			inline const char *getText() {
+			inline const char *GetText() {
 				return lv_textarea_get_text((const lv_obj_t *)_obj);
 			}
 
@@ -258,7 +257,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          pointer to the text
 			 */
-			inline const char *getPlaceholderText() {
+			inline const char *GetPlaceholderText() {
 				return lv_textarea_get_placeholder_text(_obj);
 			}
 
@@ -267,7 +266,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          pointer to the label object
 			 */
-			inline lv_obj_t *getLabel() {
+			inline lv_obj_t *GetLabel() {
 				return lv_textarea_get_label((const lv_obj_t *)_obj);
 			}
 
@@ -276,7 +275,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          the cursor position
 			 */
-			inline uint32_t getCursorPos() {
+			inline uint32_t GetCursorPos() {
 				return lv_textarea_get_cursor_pos((const lv_obj_t *)_obj);
 			}
 
@@ -285,7 +284,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          true: enable click positions; false: disable
 			 */
-			inline bool getCursorClickPos() {
+			inline bool GetCursorClickPos() {
 				return lv_textarea_get_cursor_click_pos(_obj);
 			}
 
@@ -294,7 +293,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          true: password mode is enabled, false: disabled
 			 */
-			inline bool getPasswordMode() {
+			inline bool GetPasswordMode() {
 				return lv_textarea_get_password_mode((const lv_obj_t *)_obj);
 			}
 
@@ -303,7 +302,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          pointer to the replacement text
 			 */
-			inline const char *getPasswordBullet() {
+			inline const char *GetPasswordBullet() {
 				return lv_textarea_get_password_bullet(_obj);
 			}
 
@@ -312,7 +311,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          true: one line configuration is enabled, false: disabled
 			 */
-			inline bool getOneLine() {
+			inline bool GetOneLine() {
 				return lv_textarea_get_one_line((const lv_obj_t *)_obj);
 			}
 
@@ -321,7 +320,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          list of accented characters.
 			 */
-			inline const char *getAcceptedChars() {
+			inline const char *GetAcceptedChars() {
 				return lv_textarea_get_accepted_chars(_obj);
 			}
 
@@ -330,7 +329,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          the maximal number of characters to be add
 			 */
-			inline uint32_t getMaxLength() {
+			inline uint32_t GetMaxLength() {
 				return lv_textarea_get_max_length(_obj);
 			}
 
@@ -339,7 +338,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          whether text is selected or not
 			 */
-			inline bool textIsSelected() {
+			inline bool TextIsSelected() {
 				return lv_textarea_text_is_selected((const lv_obj_t *)_obj);
 			}
 
@@ -348,7 +347,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          true: selection mode is enabled, false: disabled
 			 */
-			inline bool getTextSelection() {
+			inline bool GetTextSelection() {
 				return lv_textarea_get_text_selection(_obj);
 			}
 
@@ -357,7 +356,7 @@ namespace lvgl {
 			 * @param obj       pointer to a text area object
 			 * @return          show time in milliseconds. 0: hide immediately.
 			 */
-			inline uint16_t getPasswordShowTime() {
+			inline uint16_t GetPasswordShowTime() {
 				return lv_textarea_get_password_show_time(_obj);
 			}
 
@@ -369,7 +368,7 @@ namespace lvgl {
 			 * Clear the selection on the text area.
 			 * @param obj       pointer to a text area object
 			 */
-			inline TextArea *clearSelection() {
+			inline TextArea *ClearSelection() {
 				lv_textarea_clear_selection(_obj);
 				return this;
 			}
@@ -378,7 +377,7 @@ namespace lvgl {
 			 * Move the cursor one character right
 			 * @param obj       pointer to a text area object
 			 */
-			inline TextArea *cursorRight() {
+			inline TextArea *CursorRight() {
 				lv_textarea_cursor_right(_obj);
 				return this;
 			}
@@ -387,7 +386,7 @@ namespace lvgl {
 			 * Move the cursor one character left
 			 * @param obj       pointer to a text area object
 			 */
-			inline TextArea *cursorLeft() {
+			inline TextArea *CursorLeft() {
 				lv_textarea_cursor_left(_obj);
 				return this;
 			}
@@ -396,7 +395,7 @@ namespace lvgl {
 			 * Move the cursor one line down
 			 * @param obj       pointer to a text area object
 			 */
-			inline TextArea *cursorDown() {
+			inline TextArea *CursorDown() {
 				lv_textarea_cursor_down(_obj);
 				return this;
 			}
@@ -405,7 +404,7 @@ namespace lvgl {
 			 * Move the cursor one line up
 			 * @param obj       pointer to a text area object
 			 */
-			inline TextArea *cursorUp() {
+			inline TextArea *CursorUp() {
 				lv_textarea_cursor_up(_obj);
 				return this;
 			}


### PR DESCRIPTION
Due to namespace usage and other considerations I decided to fallow a syntax convention, so: 

Private variables, functions and namespaces will begin with lower case letter. 

Public functions and variables will begin with upper case letter. 

Enumerations and definitions will contain all letters as upper case, but definitions will have a dash as first character.

That way developer will always know what type is only reading the code.